### PR TITLE
Adapt readme and contributing guide to create-eth repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,18 @@
-# Welcome to Scaffold-ETH 2 Contributing Guide
+# Welcome to create-eth Contributing Guide
 
-Thank you for investing your time in contributing to Scaffold-ETH 2!
+Thank you for investing your time in contributing to create-eth!
 
 This guide aims to provide an overview of the contribution workflow to help us make the contribution process effective for everyone involved.
 
 ## About the Project
 
-Scaffold-ETH 2 is CLI tool to create a minimal repo providing builders with a starter kit to build decentralized applications on Ethereum.
+create-eth is a CLI tool to create a minimal repo to build decentralized applications on Ethereum, providing builders with a starter kit based on Scaffold-ETH 2.
 
 Read the [README](README.md) to get an overview of the project.
 
 ### Vision
 
-The goal of Scaffold-ETH 2 is to provide the primary building blocks for a decentralized application.
+The goal of create-eth is to be a "toolkit creator", using Scaffold-ETH 2 as a base to provide the primary building blocks for a decentralized application. In the future we plan to add "curated" packages to it, and open the possibility to import 3rd party packages (that follow our standard).
 
 The repo can be forked to include integrations and more features.
 
@@ -44,7 +44,7 @@ Issues should be used to report problems, request a new feature, or discuss pote
 
 #### Solve an issue
 
-Scan through our [existing issues](https://github.com/scaffold-eth/scaffold-eth-2/issues) to find one that interests you.
+Scan through our [existing issues](https://github.com/scaffold-eth/create-eth/issues) to find one that interests you.
 
 If a contributor is working on the issue, they will be assigned to the individual. If you find an issue to work on, you are welcome to assign it to yourself and open a PR with a fix for it.
 
@@ -66,11 +66,15 @@ We follow the ["fork-and-pull" Git workflow](https://github.com/susam/gitpr)
 
 1. Fork the repo
 2. Clone the project
-3. Create a new branch with a descriptive name
+3. Create a new branch (based in create-eth main branch) with a descriptive name
 4. Commit your changes to the new branch
 5. Add [changeset](#changeset) if applicable
 6. Push changes to your fork
 7. Open a PR in our repository and tag one of the maintainers to review your PR
+
+> ⚠️ **Important.** Please make sure to choose **create-eth** repo when you create your branch and compare your changes.
+>
+> This repo is a fork of Scaffold-ETH 2, and it may appear as default repo when creating a branch or PR.
 
 Here are some tips for a high-quality pull request:
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,16 @@
-> ⚠️ The [CLI branch](https://github.com/scaffold-eth/scaffold-eth-2/tree/cli) is under active development.  
-> If you find any bug, please report as [issue](https://github.com/scaffold-eth/scaffold-eth-2/issues) or send a message in [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)
+> ⚠️ Under active development.
+>
+> If you find any bug, please report as [issue](https://github.com/scaffold-eth/create-eth/issues) or send a message in [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)
 
-# 🏗 Scaffold-ETH 2
+# 🏗 create-eth
+
+CLI to create decentralized applications (dapps) using Scaffold-ETH 2.
 
 <h4 align="center">
-  <a href="https://docs.scaffoldeth.io">Documentation</a> |
-  <a href="https://scaffoldeth.io">Website</a>
+  <a href="https://github.com/scaffold-eth/scaffold-eth-2">SE-2 Repo</a> |
+  <a href="https://docs.scaffoldeth.io">SE-2 Docs</a> |
+  <a href="https://scaffoldeth.io">SE-2 Website</a>
 </h4>
-
-🧪 An open-source, up-to-date toolkit for building decentralized applications (dapps) on the Ethereum blockchain. It's designed to make it easier for developers to create and deploy smart contracts and build user interfaces that interact with those contracts.
-
-⚙️ Built using NextJS, RainbowKit, Hardhat, Wagmi, Viem, and Typescript.
-
-- ✅ **Contract Hot Reload**: Your frontend auto-adapts to your smart contract as you edit it.
-- 🪝 **[Custom hooks](https://docs.scaffoldeth.io/hooks/)**: Collection of React hooks wrapper around [wagmi](https://wagmi.sh/) to simplify interactions with smart contracts with typescript autocompletion.
-- 🧱 [**Components**](https://docs.scaffoldeth.io/components/): Collection of common web3 components to quickly build your frontend.
-- 🔥 **Burner Wallet & Local Faucet**: Quickly test your application with a burner wallet and local faucet.
-- 🔐 **Integration with Wallet Providers**: Connect to different wallet providers and interact with the Ethereum network.
-
-![Debug Contracts tab](https://github.com/scaffold-eth/scaffold-eth-2/assets/55535804/b237af0c-5027-4849-a5c1-2e31495cccb1)
 
 ## Requirements
 
@@ -90,8 +82,11 @@ Visit our [docs](https://docs.scaffoldeth.io) to learn how to start building wit
 
 To know more about its features, check out our [website](https://scaffoldeth.io).
 
-## Contributing to Scaffold-ETH 2
+## Contributing to create-eth
 
-We welcome contributions to Scaffold-ETH 2!
+We welcome contributions to create-eth and Scaffold-ETH 2!
 
-Please see [CONTRIBUTING.MD](https://github.com/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) for more information and guidelines for contributing to Scaffold-ETH 2.
+For more information and guidelines for contributing, please see:
+
+- [create-eth CONTRIBUTING.MD](https://github.com/scaffold-eth/create-eth/blob/main/CONTRIBUTING.md) if you want to contribute to the CLI.
+- [Scaffold-ETH 2 CONTRIBUTING.MD](https://github.com/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) if you want to contribute to SE-2 base code.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 CLI to create decentralized applications (dapps) using Scaffold-ETH 2.
 
+This is an alternative method of installing Scaffold-ETH. Instead of directly [cloning SE-2](https://docs.scaffoldeth.io/quick-start/installation#option-1-setup-using-git-clone), you can use create-eth to create your own custom instance, where you can choose among several configurations and extensions.
+
 <h4 align="center">
   <a href="https://github.com/scaffold-eth/scaffold-eth-2">SE-2 Repo</a> |
   <a href="https://docs.scaffoldeth.io">SE-2 Docs</a> |


### PR DESCRIPTION
Initial tweaks to adapt old SE-2 Readme and Contributing guide to new create-eth repo.

Maybe I deleted too much stuff in Readme for a initial iteration, we can get back basic SE-2 screenshot and features from initial part of the Readme if you prefer 🙌

Fixes #10 