### PR TITLE
Configure eslint and prettiier

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+yarn lint-staged --verbose

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn lint-staged --verbose
+yarn lint-staged --verbose --config ./.lintstagedrc.json

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,3 @@
+{
+  "*.{js,ts,md}": "eslint --fix"
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+templates

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,10 @@
+# yarn
+.yarn
+.yarnrc
+.yarnrc.yml
+
+# Changelog
+CHANGELOG.md
+
+# Templates dir
 templates

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "arrowParens": "avoid",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/contributors/RFC-extensions.md
+++ b/contributors/RFC-extensions.md
@@ -122,7 +122,9 @@ Also, receiving an array instead of strings give the template itself more contro
 Important to note that named arguments could use any arbitrary name. Because of that, we have to provide default values to all those arguments, otherwise missing values would be parsed as the string "undefined". Because we don't know what are the expected names for each template expects.
 
 ## Things to note about Template files
+
 ### `.mjs` extension
+
 It's important to note the file extension should be `.mjs`. The CLI uses es6 modules, but other packages might use commonjs imports, like Hardhat.
 
 When a package enforces commonjs imports, our templates created within those packages wouldn't work unless we explicitly tell node that it should use es6 imports. Using `.mjs` extensions is the best way we've found to do that.
@@ -134,21 +136,22 @@ It's a bit annoying having to define an empty array as a default value for all t
 As a bonus, using this function will throw an error when an [Args file](#args-file-content) is trying to send an argument with a name not expected by the template.
 
 The way it should be used is as follows:
+
 ```js
 // file.ext.template.mjs
-import { withDefaults } from '../path-to/utils.js'
+import { withDefaults } from "../path-to/utils.js";
 
 const contents = ({ foo, bar }) =>
-`blah blah
+  `blah blah
 foo value is ${foo}
 bar value is ${bar}
 blah blah
-`
+`;
 
 export default withDefaults(contents, {
-  foo: 'default foo value',
-  bar: 'default bar value'
-})
+  foo: "default foo value",
+  bar: "default bar value",
+});
 ```
 
 There's an optional 3rd argument that's for debugging purposes, which is `false` by default. If sent `true`, it will print some information about the arguments received.
@@ -157,14 +160,14 @@ There's an optional 3rd argument that's for debugging purposes, which is `false`
 
 ```js
 // file.ext.template.mjs
-import { withDefaults } from '../path-to/utils.js'
+import { withDefaults } from "../path-to/utils.js";
 
-const contents = ({ foo, bar }) => `${foo} and ${bar}`
+const contents = ({ foo, bar }) => `${foo} and ${bar}`;
 
 export default withDefaults(contents, {
-  foo: 'default',
+  foo: "default",
   // bar: 'not defined!'
-})
+});
 
 // result: "default and undefined"
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,4 +29,9 @@ export default tseslint.config(
     ignores: [".changeset", ".yarn", "bin", "dist", "templates"],
   },
   eslintPluginPrettierRecommended,
+  {
+    rules: {
+      "prettier/prettier": ["warn", { endOfLine: "auto" }],
+    },
+  },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,32 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.json",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+    },
+  },
+  {
+    files: ["**/*.js"],
+    ...tseslint.configs.disableTypeChecked,
+  },
+  {
+    ignores: [".changeset", ".yarn", "bin", "dist", "templates"],
+  },
+  eslintPluginPrettierRecommended,
+);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "changeset:release": "yarn build && changeset publish"
+    "changeset:release": "yarn build && changeset publish",
+    "prepare": "husky"
   },
   "keywords": [
     "cli",
@@ -39,6 +40,8 @@
     "eslint": "^9.3.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.4",
     "prettier": "3.2.5",
     "rollup": "3.21.0",
     "rollup-plugin-auto-external": "2.0.0",
@@ -57,6 +60,9 @@
     "merge-packages": "^0.1.6",
     "ncp": "2.0.0",
     "pkg-install": "1.0.0"
+  },
+  "lint-staged": {
+    "*.{js,ts,md}": "eslint --fix"
   },
   "packageManager": "yarn@3.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "rollup -c rollup.config.js",
     "dev": "rollup -c rollup.config.js --watch",
     "cli": "node bin/create-dapp-se2.js",
+    "format": "prettier --write .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "changeset:release": "yarn build && changeset publish"
   },
@@ -33,6 +34,7 @@
     "@types/listr": "0.14.4",
     "@types/ncp": "2.0.5",
     "@types/node": "18.16.0",
+    "prettier": "3.2.5",
     "rollup": "3.21.0",
     "rollup-plugin-auto-external": "2.0.0",
     "tslib": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "rollup -c rollup.config.js",
     "dev": "rollup -c rollup.config.js --watch",
     "cli": "node bin/create-dapp-se2.js",
+    "lint": "eslint .",
     "format": "prettier --write .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "changeset:release": "yarn build && changeset publish"
@@ -29,16 +30,21 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@eslint/js": "^9.3.0",
     "@rollup/plugin-typescript": "11.1.0",
     "@types/inquirer": "9.0.3",
     "@types/listr": "0.14.4",
     "@types/ncp": "2.0.5",
     "@types/node": "18.16.0",
+    "eslint": "^9.3.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "prettier": "3.2.5",
     "rollup": "3.21.0",
     "rollup-plugin-auto-external": "2.0.0",
     "tslib": "2.5.0",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "typescript-eslint": "^7.10.0"
   },
   "dependencies": {
     "@changesets/cli": "^2.26.2",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,5 @@
     "ncp": "2.0.0",
     "pkg-install": "1.0.0"
   },
-  "lint-staged": {
-    "*.{js,ts,md}": "eslint --fix"
-  },
   "packageManager": "yarn@3.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format": "prettier --write .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "changeset:release": "yarn build && changeset publish",
-    "prepare": "husky"
+    "postinstall": "husky"
   },
   "keywords": [
     "cli",

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ const CURATED_EXTENSIONS: { [key: string]: ExternalExtension } = {
   subgraph: {
     repository: "https://github.com/scaffold-eth/create-eth-extensions",
     branch: "subgraph",
-  }
-}
+  },
+};
 
 export { config, CURATED_EXTENSIONS };

--- a/src/declarations/merge-pacakges.d.ts
+++ b/src/declarations/merge-pacakges.d.ts
@@ -1,0 +1,6 @@
+declare module "merge-packages" {
+  const mergePackages: {
+    default: (target: string, second: string) => string;
+  };
+  export default mergePackages;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,7 @@ export async function createProject(options: Options) {
 
   try {
     await tasks.run();
-    renderOutroMessage(options);
+    await renderOutroMessage(options);
   } catch (error) {
     console.log("%s Error occurred", chalk.red.bold("ERROR"), error);
     console.log("%s Exiting...", chalk.red.bold("Uh oh! 😕 Sorry about that!"));

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,10 +18,7 @@ export async function createProject(options: Options) {
 
   const currentFileUrl = import.meta.url;
 
-  const templateDirectory = path.resolve(
-    decodeURI(fileURLToPath(currentFileUrl)),
-    "../../templates"
-  );
+  const templateDirectory = path.resolve(decodeURI(fileURLToPath(currentFileUrl)), "../../templates");
 
   const targetDirectory = path.resolve(process.cwd(), options.project);
 
@@ -32,10 +29,9 @@ export async function createProject(options: Options) {
     },
     {
       title: `🚀 Creating a new Scaffold-ETH 2 app in ${chalk.green.bold(
-        options.project
+        options.project,
       )}${options.externalExtension ? ` with the ${chalk.green.bold(getArgumentFromExternalExtensionOption(options.externalExtension))} extension` : ""}`,
-      task: () =>
-        copyTemplateFiles(options, templateDirectory, targetDirectory),
+      task: () => copyTemplateFiles(options, templateDirectory, targetDirectory),
     },
     {
       title: `📦 Installing dependencies with yarn, this could take a while`,
@@ -56,9 +52,7 @@ export async function createProject(options: Options) {
       },
     },
     {
-      title: `📡 Initializing Git repository ${
-        options.extensions.includes("foundry") ? "and submodules" : ""
-      }`,
+      title: `📡 Initializing Git repository ${options.extensions.includes("foundry") ? "and submodules" : ""}`,
       task: () => createFirstGitCommit(targetDirectory, options),
     },
   ]);

--- a/src/tasks/copy-template-files.ts
+++ b/src/tasks/copy-template-files.ts
@@ -10,25 +10,19 @@ import ncp from "ncp";
 import path from "path";
 import { promisify } from "util";
 import link from "../utils/link";
-import {getArgumentFromExternalExtensionOption} from "../utils/external-extensions";
+import { getArgumentFromExternalExtensionOption } from "../utils/external-extensions";
 
 const EXTERNAL_EXTENSION_TMP_FOLDER = "tmp-external-extension";
 const copy = promisify(ncp);
 let copyOrLink = copy;
 
-
 const expandExtensions = (options: Options): Extension[] => {
   const expandedExtensions = options.extensions
-    .map((extension) => extensionDict[extension])
-    .map((extDescriptor) =>
-      [extDescriptor.extends, extDescriptor.value].filter(isDefined)
-    )
+    .map(extension => extensionDict[extension])
+    .map(extDescriptor => [extDescriptor.extends, extDescriptor.value].filter(isDefined))
     .flat()
     // this reduce just removes duplications
-    .reduce(
-      (exts, ext) => (exts.includes(ext) ? exts : [...exts, ext]),
-      [] as Extension[]
-    );
+    .reduce((exts, ext) => (exts.includes(ext) ? exts : [...exts, ext]), [] as Extension[]);
 
   return expandedExtensions;
 };
@@ -36,100 +30,71 @@ const expandExtensions = (options: Options): Extension[] => {
 const isTemplateRegex = /([^\/\\]*?)\.template\./;
 const isPackageJsonRegex = /package\.json/;
 const isYarnLockRegex = /yarn\.lock/;
-const isNextGeneratedRegex = /packages\/nextjs\/generated/
+const isNextGeneratedRegex = /packages\/nextjs\/generated/;
 const isConfigRegex = /([^\/\\]*?)\\config\.json/;
 const isArgsRegex = /([^\/\\]*?)\.args\./;
 const isExtensionFolderRegex = /extensions$/;
 const isPackagesFolderRegex = /packages$/;
 
-const copyBaseFiles = async (
-    { dev: isDev }: Options,
-    basePath: string,
-    targetDir: string
-  ) => {
+const copyBaseFiles = async ({ dev: isDev }: Options, basePath: string, targetDir: string) => {
   await copyOrLink(basePath, targetDir, {
     clobber: false,
-    filter: (fileName) => {  // NOTE: filter IN
-      const isTemplate = isTemplateRegex.test(fileName)
-      const isPackageJson = isPackageJsonRegex.test(fileName)
-      const isYarnLock = isYarnLockRegex.test(fileName)
-      const isNextGenerated = isNextGeneratedRegex.test(fileName)
+    filter: fileName => {
+      // NOTE: filter IN
+      const isTemplate = isTemplateRegex.test(fileName);
+      const isPackageJson = isPackageJsonRegex.test(fileName);
+      const isYarnLock = isYarnLockRegex.test(fileName);
+      const isNextGenerated = isNextGeneratedRegex.test(fileName);
 
-      const skipAlways = isTemplate || isPackageJson
-      const skipDevOnly = isYarnLock || isNextGenerated
-      const shouldSkip = skipAlways || (isDev && skipDevOnly)
+      const skipAlways = isTemplate || isPackageJson;
+      const skipDevOnly = isYarnLock || isNextGenerated;
+      const shouldSkip = skipAlways || (isDev && skipDevOnly);
 
-      return !shouldSkip
+      return !shouldSkip;
     },
   });
 
-  const basePackageJsonPaths = findFilesRecursiveSync(basePath, path => isPackageJsonRegex.test(path))
+  const basePackageJsonPaths = findFilesRecursiveSync(basePath, path => isPackageJsonRegex.test(path));
 
   basePackageJsonPaths.forEach(packageJsonPath => {
-    const partialPath = packageJsonPath.split(basePath)[1]
-    mergePackageJson(
-      path.join(targetDir, partialPath),
-      path.join(basePath, partialPath),
-      isDev
-    );
-  })
+    const partialPath = packageJsonPath.split(basePath)[1];
+    mergePackageJson(path.join(targetDir, partialPath), path.join(basePath, partialPath), isDev);
+  });
 
   if (isDev) {
-    const baseYarnLockPaths = findFilesRecursiveSync(basePath, path => isYarnLockRegex.test(path))
+    const baseYarnLockPaths = findFilesRecursiveSync(basePath, path => isYarnLockRegex.test(path));
     baseYarnLockPaths.forEach(yarnLockPath => {
-      const partialPath = yarnLockPath.split(basePath)[1]
-      copy(
-        path.join(basePath, partialPath),
-        path.join(targetDir, partialPath)
-      )
-    })
+      const partialPath = yarnLockPath.split(basePath)[1];
+      copy(path.join(basePath, partialPath), path.join(targetDir, partialPath));
+    });
 
-    const nextGeneratedPaths = findFilesRecursiveSync(basePath, path => isNextGeneratedRegex.test(path))
+    const nextGeneratedPaths = findFilesRecursiveSync(basePath, path => isNextGeneratedRegex.test(path));
     nextGeneratedPaths.forEach(nextGeneratedPath => {
-      const partialPath = nextGeneratedPath.split(basePath)[1]
-      copy(
-        path.join(basePath, partialPath),
-        path.join(targetDir, partialPath)
-      )
-    })
+      const partialPath = nextGeneratedPath.split(basePath)[1];
+      copy(path.join(basePath, partialPath), path.join(targetDir, partialPath));
+    });
   }
-}
+};
 
-const copyExtensionsFiles = async (
-  { dev: isDev }: Options,
-  extensionPath: string,
-  targetDir: string
-) => {
+const copyExtensionsFiles = async ({ dev: isDev }: Options, extensionPath: string, targetDir: string) => {
   // copy (or link if dev) root files
   await copyOrLink(extensionPath, path.join(targetDir), {
     clobber: false,
-    filter: (path) => {
+    filter: path => {
       const isConfig = isConfigRegex.test(path);
       const isArgs = isArgsRegex.test(path);
-      const isExtensionFolder =
-        isExtensionFolderRegex.test(path) && fs.lstatSync(path).isDirectory();
-      const isPackagesFolder =
-        isPackagesFolderRegex.test(path) && fs.lstatSync(path).isDirectory();
+      const isExtensionFolder = isExtensionFolderRegex.test(path) && fs.lstatSync(path).isDirectory();
+      const isPackagesFolder = isPackagesFolderRegex.test(path) && fs.lstatSync(path).isDirectory();
       const isTemplate = isTemplateRegex.test(path);
       // PR NOTE: this wasn't needed before because ncp had the clobber: false
       const isPackageJson = isPackageJsonRegex.test(path);
-      const shouldSkip =
-        isConfig ||
-        isArgs ||
-        isTemplate ||
-        isPackageJson ||
-        isExtensionFolder ||
-        isPackagesFolder;
+      const shouldSkip = isConfig || isArgs || isTemplate || isPackageJson || isExtensionFolder || isPackagesFolder;
       return !shouldSkip;
     },
   });
 
   // merge root package.json
-  mergePackageJson(
-    path.join(targetDir, "package.json"),
-    path.join(extensionPath, "package.json"),
-    isDev
-  );
+  mergePackageJson(path.join(targetDir, "package.json"), path.join(extensionPath, "package.json"), isDev);
 
   const extensionPackagesPath = path.join(extensionPath, "packages");
   const hasPackages = fs.existsSync(extensionPackagesPath);
@@ -137,7 +102,7 @@ const copyExtensionsFiles = async (
     // copy extension packages files
     await copyOrLink(extensionPackagesPath, path.join(targetDir, "packages"), {
       clobber: false,
-      filter: (path) => {
+      filter: path => {
         const isArgs = isArgsRegex.test(path);
         const isTemplate = isTemplateRegex.test(path);
         const isPackageJson = isPackageJsonRegex.test(path);
@@ -149,54 +114,52 @@ const copyExtensionsFiles = async (
 
     // copy each package's package.json
     const extensionPackages = fs.readdirSync(extensionPackagesPath);
-    extensionPackages.forEach((packageName) => {
+    extensionPackages.forEach(packageName => {
       mergePackageJson(
         path.join(targetDir, "packages", packageName, "package.json"),
         path.join(extensionPath, "packages", packageName, "package.json"),
-        isDev
+        isDev,
       );
     });
   }
-
 };
 
 const processTemplatedFiles = async (
   { extensions, externalExtension, dev: isDev }: Options,
   basePath: string,
-  targetDir: string
+  targetDir: string,
 ) => {
-  const baseTemplatedFileDescriptors: TemplateDescriptor[] =
-    findFilesRecursiveSync(basePath, (path) => isTemplateRegex.test(path)).map(
-      (baseTemplatePath) => ({
-        path: baseTemplatePath,
-        fileUrl: url.pathToFileURL(baseTemplatePath).href,
-        relativePath: baseTemplatePath.split(basePath)[1],
-        source: "base",
-      })
-    );
+  const baseTemplatedFileDescriptors: TemplateDescriptor[] = findFilesRecursiveSync(basePath, path =>
+    isTemplateRegex.test(path),
+  ).map(baseTemplatePath => ({
+    path: baseTemplatePath,
+    fileUrl: url.pathToFileURL(baseTemplatePath).href,
+    relativePath: baseTemplatePath.split(basePath)[1],
+    source: "base",
+  }));
 
   const extensionsTemplatedFileDescriptors: TemplateDescriptor[] = extensions
-    .map((ext) =>
-      findFilesRecursiveSync(extensionDict[ext].path, (filePath) =>
-        isTemplateRegex.test(filePath)
-      ).map((extensionTemplatePath) => ({
-        path: extensionTemplatePath,
-        fileUrl: url.pathToFileURL(extensionTemplatePath).href,
-        relativePath: extensionTemplatePath.split(extensionDict[ext].path)[1],
-        source: `extension ${extensionDict[ext].name}`,
-      }))
+    .map(ext =>
+      findFilesRecursiveSync(extensionDict[ext].path, filePath => isTemplateRegex.test(filePath)).map(
+        extensionTemplatePath => ({
+          path: extensionTemplatePath,
+          fileUrl: url.pathToFileURL(extensionTemplatePath).href,
+          relativePath: extensionTemplatePath.split(extensionDict[ext].path)[1],
+          source: `extension ${extensionDict[ext].name}`,
+        }),
+      ),
     )
     .flat();
 
   const externalExtensionTemplatedFileDescriptors: TemplateDescriptor[] = externalExtension
-    ? findFilesRecursiveSync(path.join(targetDir, EXTERNAL_EXTENSION_TMP_FOLDER, "extension"), (filePath) =>
-      isTemplateRegex.test(filePath)
-    ).map((extensionTemplatePath) => ({
-      path: extensionTemplatePath,
-      fileUrl: url.pathToFileURL(extensionTemplatePath).href,
-      relativePath: extensionTemplatePath.split(path.join(targetDir, EXTERNAL_EXTENSION_TMP_FOLDER, "extension"))[1],
-      source: `external extension ${getArgumentFromExternalExtensionOption(externalExtension)}`,
-    }))
+    ? findFilesRecursiveSync(path.join(targetDir, EXTERNAL_EXTENSION_TMP_FOLDER, "extension"), filePath =>
+        isTemplateRegex.test(filePath),
+      ).map(extensionTemplatePath => ({
+        path: extensionTemplatePath,
+        fileUrl: url.pathToFileURL(extensionTemplatePath).href,
+        relativePath: extensionTemplatePath.split(path.join(targetDir, EXTERNAL_EXTENSION_TMP_FOLDER, "extension"))[1],
+        source: `external extension ${getArgumentFromExternalExtensionOption(externalExtension)}`,
+      }))
     : [];
 
   await Promise.all(
@@ -204,21 +167,14 @@ const processTemplatedFiles = async (
       ...baseTemplatedFileDescriptors,
       ...extensionsTemplatedFileDescriptors,
       ...externalExtensionTemplatedFileDescriptors,
-    ].map(async (templateFileDescriptor) => {
-      const templateTargetName =
-        templateFileDescriptor.path.match(isTemplateRegex)?.[1]!;
+    ].map(async templateFileDescriptor => {
+      const templateTargetName = templateFileDescriptor.path.match(isTemplateRegex)?.[1]!;
 
-      const argsPath = templateFileDescriptor.relativePath.replace(
-        isTemplateRegex,
-        `${templateTargetName}.args.`
-      );
+      const argsPath = templateFileDescriptor.relativePath.replace(isTemplateRegex, `${templateTargetName}.args.`);
 
       const argsFileUrls = extensions
-        .map((extension) => {
-          const argsFilePath = path.join(
-            extensionDict[extension].path,
-            argsPath
-          );
+        .map(extension => {
+          const argsFilePath = path.join(extensionDict[extension].path, argsPath);
           const fileExists = fs.existsSync(argsFilePath);
           if (!fileExists) {
             return [];
@@ -236,39 +192,34 @@ const processTemplatedFiles = async (
         }
       }
 
-      const args = await Promise.all(
-        argsFileUrls.map(async (argsFileUrl) => await import(argsFileUrl))
-      );
+      const args = await Promise.all(argsFileUrls.map(async argsFileUrl => await import(argsFileUrl)));
 
       const fileTemplate = (await import(templateFileDescriptor.fileUrl)).default;
 
       if (!fileTemplate) {
         throw new Error(
-          `Template ${templateTargetName} from ${templateFileDescriptor.source} doesn't have a default export`
+          `Template ${templateTargetName} from ${templateFileDescriptor.source} doesn't have a default export`,
         );
       }
       if (typeof fileTemplate !== "function") {
         throw new Error(
-          `Template ${templateTargetName} from ${templateFileDescriptor.source} is not exporting a function by default`
+          `Template ${templateTargetName} from ${templateFileDescriptor.source} is not exporting a function by default`,
         );
       }
 
       // ToDo. Bug, if arg not present in arg[0], but present in arg[1], it will not be added.
       const freshArgs: { [key: string]: string[] } = Object.fromEntries(
-        Object.keys(args[0] ?? {}).map((key) => [
+        Object.keys(args[0] ?? {}).map(key => [
           key, // INFO: key for the freshArgs object
           [], // INFO: initial value for the freshArgs object
-        ])
+        ]),
       );
-      const combinedArgs: { [key: string]: string[] } = args.reduce(
-        (accumulated, arg) => {
-          Object.entries(arg).map(([key, value]) => {
-            accumulated[key]?.push(value);
-          });
-          return accumulated;
-        },
-        freshArgs
-      );
+      const combinedArgs: { [key: string]: string[] } = args.reduce((accumulated, arg) => {
+        Object.entries(arg).map(([key, value]) => {
+          accumulated[key]?.push(value);
+        });
+        return accumulated;
+      }, freshArgs);
 
       // TODO test: if first arg file found only uses 1 name, I think the rest are not used?
 
@@ -277,43 +228,42 @@ const processTemplatedFiles = async (
       const targetPath = path.join(
         targetDir,
         templateFileDescriptor.relativePath.split(templateTargetName)[0],
-        templateTargetName
+        templateTargetName,
       );
       fs.writeFileSync(targetPath, output);
 
       if (isDev) {
-        const hasCombinedArgs = Object.keys(combinedArgs).length > 0
-        const hasArgsPaths = argsFileUrls.length > 0
+        const hasCombinedArgs = Object.keys(combinedArgs).length > 0;
+        const hasArgsPaths = argsFileUrls.length > 0;
         const devOutput = `--- TEMPLATE FILE
 templates/${templateFileDescriptor.source}${templateFileDescriptor.relativePath}
 
 
 --- ARGS FILES
-${hasArgsPaths
-  ? argsFileUrls.map(url => `\t- ${path.join('templates', url.split('templates')[1])}`).join('\n')
-  : '(no args files writing to the template)'
+${
+  hasArgsPaths
+    ? argsFileUrls.map(url => `\t- ${path.join("templates", url.split("templates")[1])}`).join("\n")
+    : "(no args files writing to the template)"
 }
 
 
 --- RESULTING ARGS
-${hasCombinedArgs
-  ? Object.entries(combinedArgs)
-  .map(([argName, argValue]) => `\t- ${argName}:\t[${argValue.join(',')}]`)
-  // TODO improvement: figure out how to add the values added by each args file
-  .join('\n')
-  : '(no args sent for the template)'
+${
+  hasCombinedArgs
+    ? Object.entries(combinedArgs)
+        .map(([argName, argValue]) => `\t- ${argName}:\t[${argValue.join(",")}]`)
+        // TODO improvement: figure out how to add the values added by each args file
+        .join("\n")
+    : "(no args sent for the template)"
 }
-`
+`;
         fs.writeFileSync(`${targetPath}.dev`, devOutput);
       }
-    })
+    }),
   );
 };
 
-const setUpExternalExtensionFiles = async (
-  options: Options,
-  tmpDir: string,
-) => {
+const setUpExternalExtensionFiles = async (options: Options, tmpDir: string) => {
   // 1. Create tmp directory to clone external extension
   await fs.promises.mkdir(tmpDir);
 
@@ -330,11 +280,7 @@ const setUpExternalExtensionFiles = async (
   }
 };
 
-export async function copyTemplateFiles(
-  options: Options,
-  templateDir: string,
-  targetDir: string
-) {
+export async function copyTemplateFiles(options: Options, templateDir: string, targetDir: string) {
   copyOrLink = options.dev ? link : copy;
   const basePath = path.join(templateDir, baseDir);
   const tmpDir = path.join(targetDir, EXTERNAL_EXTENSION_TMP_FOLDER);
@@ -346,10 +292,12 @@ export async function copyTemplateFiles(
   options.extensions = expandExtensions(options);
 
   // 3. Copy extensions folders
-  await Promise.all(options.extensions.map(async (extension) => {
-    const extensionPath = extensionDict[extension].path;
-    await copyExtensionsFiles(options, extensionPath, targetDir);
-  }));
+  await Promise.all(
+    options.extensions.map(async extension => {
+      const extensionPath = extensionDict[extension].path;
+      await copyExtensionsFiles(options, extensionPath, targetDir);
+    }),
+  );
 
   // 4. Set up external extension if needed
   if (options.externalExtension) {

--- a/src/tasks/create-first-git-commit.ts
+++ b/src/tasks/create-first-git-commit.ts
@@ -21,71 +21,37 @@ async function checkoutLatestTag(submodulePath: string): Promise<void> {
   }
 }
 
-export async function createFirstGitCommit(
-  targetDir: string,
-  options: Options
-) {
+export async function createFirstGitCommit(targetDir: string, options: Options) {
   try {
     // TODO: Move the logic for adding submodules to tempaltes
     if (options.extensions?.includes("foundry")) {
-      const foundryWorkSpacePath = path.resolve(
-        targetDir,
-        "packages",
-        "foundry"
+      const foundryWorkSpacePath = path.resolve(targetDir, "packages", "foundry");
+      await execa("git", ["submodule", "add", "https://github.com/foundry-rs/forge-std", "lib/forge-std"], {
+        cwd: foundryWorkSpacePath,
+      });
+      await execa(
+        "git",
+        ["submodule", "add", "https://github.com/OpenZeppelin/openzeppelin-contracts", "lib/openzeppelin-contracts"],
+        {
+          cwd: foundryWorkSpacePath,
+        },
       );
       await execa(
         "git",
-        [
-          "submodule",
-          "add",
-          "https://github.com/foundry-rs/forge-std",
-          "lib/forge-std",
-        ],
+        ["submodule", "add", "https://github.com/gnsps/solidity-bytes-utils", "lib/solidity-bytes-utils"],
         {
           cwd: foundryWorkSpacePath,
-        }
-      );
-      await execa(
-        "git",
-        [
-          "submodule",
-          "add",
-          "https://github.com/OpenZeppelin/openzeppelin-contracts",
-          "lib/openzeppelin-contracts",
-        ],
-        {
-          cwd: foundryWorkSpacePath,
-        }
-      );
-      await execa(
-        "git",
-        [
-          "submodule",
-          "add",
-          "https://github.com/gnsps/solidity-bytes-utils",
-          "lib/solidity-bytes-utils",
-        ],
-        {
-          cwd: foundryWorkSpacePath,
-        }
+        },
       );
       await execa("git", ["submodule", "update", "--init", "--recursive"], {
         cwd: foundryWorkSpacePath,
       });
-      await checkoutLatestTag(
-        path.resolve(foundryWorkSpacePath, "lib", "forge-std")
-      );
-      await checkoutLatestTag(
-        path.resolve(foundryWorkSpacePath, "lib", "openzeppelin-contracts")
-      );
+      await checkoutLatestTag(path.resolve(foundryWorkSpacePath, "lib", "forge-std"));
+      await checkoutLatestTag(path.resolve(foundryWorkSpacePath, "lib", "openzeppelin-contracts"));
     }
 
     await execa("git", ["add", "-A"], { cwd: targetDir });
-    await execa(
-      "git",
-      ["commit", "-m", "Initial commit with 🏗️ Scaffold-ETH 2", "--no-verify"],
-      { cwd: targetDir }
-    );
+    await execa("git", ["commit", "-m", "Initial commit with 🏗️ Scaffold-ETH 2", "--no-verify"], { cwd: targetDir });
 
     // Update the submodule, since we have checked out the latest tag in the previous step of foundry
     if (options.extensions?.includes("foundry")) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,8 +36,7 @@ interface ExtensionQuestion<T extends ExtensionOrNull[] = ExtensionOrNull[]> {
   default?: T[number];
 }
 
-export const isExtension = (item: ExtensionOrNull): item is Extension =>
-  item !== null;
+export const isExtension = (item: ExtensionOrNull): item is Extension => item !== null;
 
 /**
  * This function makes sure that the `T` generic type is narrowed down to
@@ -48,15 +47,12 @@ export const isExtension = (item: ExtensionOrNull): item is Extension =>
  * Questions can be created without this function, just using a normal object,
  * but `default` type will be any valid Extension.
  */
-export const typedQuestion = <T extends ExtensionOrNull[]>(
-  question: ExtensionQuestion<T>
-) => question;
+export const typedQuestion = <T extends ExtensionOrNull[]>(question: ExtensionQuestion<T>) => question;
 export type Config = {
   questions: ExtensionQuestion[];
 };
 
-export const isDefined = <T>(item: T | undefined | null): item is T =>
-  item !== undefined && item !== null;
+export const isDefined = <T>(item: T | undefined | null): item is T => item !== undefined && item !== null;
 
 export type ExtensionDescriptor = {
   name: string;
@@ -74,7 +70,7 @@ export type ExtensionDict = {
 };
 
 export const extensionWithSubextensions = (
-  extension: ExtensionDescriptor | undefined
+  extension: ExtensionDescriptor | undefined,
 ): extension is ExtensionBranch => {
   return Object.prototype.hasOwnProperty.call(extension, "extensions");
 };

--- a/src/utils/extensions-tree.ts
+++ b/src/utils/extensions-tree.ts
@@ -31,7 +31,7 @@ const traverseExtensions = async (basePath: string): Promise<Extension[]> => {
 
       let config: Record<string, string> = {};
       try {
-        config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+        config = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, string>;
       } catch (error) {
         if (fs.existsSync(configPath)) {
           throw new Error(
@@ -41,8 +41,8 @@ const traverseExtensions = async (basePath: string): Promise<Extension[]> => {
           );
         }
       }
-      let name = config.name ?? ext;
-      let value = ext;
+      const name = config.name ?? ext;
+      const value = ext;
 
       const subExtensions = await traverseExtensions(extPath);
       const hasSubExtensions = subExtensions.length !== 0;

--- a/src/utils/extensions-tree.ts
+++ b/src/utils/extensions-tree.ts
@@ -7,10 +7,7 @@ export const extensionDict: ExtensionDict = {} as ExtensionDict;
 
 const currentFileUrl = import.meta.url;
 
-const templatesDirectory = path.resolve(
-  decodeURI(fileURLToPath(currentFileUrl)),
-  "../../templates"
-);
+const templatesDirectory = path.resolve(decodeURI(fileURLToPath(currentFileUrl)), "../../templates");
 
 /**
  * This function has side effects. It generates the extensionDict.
@@ -28,7 +25,7 @@ const traverseExtensions = async (basePath: string): Promise<Extension[]> => {
   }
 
   await Promise.all(
-    extensions.map(async (ext) => {
+    extensions.map(async ext => {
       const extPath = path.resolve(extensionsPath, ext);
       const configPath = path.resolve(extPath, "config.json");
 
@@ -40,7 +37,7 @@ const traverseExtensions = async (basePath: string): Promise<Extension[]> => {
           throw new Error(
             `Couldn't parse existing config.json file.
   Extension: ${ext};
-  Config file path: ${configPath}`
+  Config file path: ${configPath}`,
           );
         }
       }
@@ -62,7 +59,7 @@ const traverseExtensions = async (basePath: string): Promise<Extension[]> => {
       extensionDict[ext] = extDescriptor;
 
       return subExtensions;
-    })
+    }),
   );
 
   return extensions;

--- a/src/utils/external-extensions.ts
+++ b/src/utils/external-extensions.ts
@@ -6,9 +6,7 @@ export const getDataFromExternalExtensionArgument = (externalExtension: string) 
   // Check format: owner/project:branch (branch is optional)
   const regex = /^[^/]+\/[^/]+(:[^/]+)?$/;
   if (!regex.test(externalExtension)) {
-    throw new Error(
-      `Invalid extension format. Use "owner/project" or "owner/project:branch"`
-    );
+    throw new Error(`Invalid extension format. Use "owner/project" or "owner/project:branch"`);
   }
 
   // Extract owner, project and branch
@@ -29,7 +27,7 @@ export const getDataFromExternalExtensionArgument = (externalExtension: string) 
     owner,
     project,
   };
-}
+};
 
 // Parse the externalExtensionOption object into a argument string.
 // e.g. { repository: "owner/project", branch: "branch" } => "owner/project:branch"
@@ -40,4 +38,4 @@ export const getArgumentFromExternalExtensionOption = (externalExtensionOption: 
   const project = repository?.split("/")[4];
 
   return `${owner}/${project}${branch ? `:${branch}` : ""}`;
-}
+};

--- a/src/utils/find-files-recursively.ts
+++ b/src/utils/find-files-recursively.ts
@@ -3,16 +3,16 @@ import path from "path";
 
 export const findFilesRecursiveSync = (
   baseDir: string,
-  criteriaFn: (path: string) => boolean = () => true
+  criteriaFn: (path: string) => boolean = () => true,
 ): string[] => {
   const subPaths = fs.readdirSync(baseDir);
-  const files = subPaths.map((relativePath) => {
+  const files = subPaths.map(relativePath => {
     const fullPath = path.resolve(baseDir, relativePath);
     return fs.lstatSync(fullPath).isDirectory()
       ? [...findFilesRecursiveSync(fullPath, criteriaFn)]
       : criteriaFn(fullPath)
-      ? [fullPath]
-      : [];
+        ? [fullPath]
+        : [];
   });
 
   return files.flat();

--- a/src/utils/link.ts
+++ b/src/utils/link.ts
@@ -7,38 +7,39 @@ const { mkdir, link } = promises;
 /**
  * The goal is that this function has the same API as ncp, so they can be used
  * interchangeably.
- * 
+ *
  * - clobber not implemented
  */
 const linkRecursive = async (source: string, destination: string, options?: Options): Promise<void> => {
-  const passesFilter = options?.filter === undefined
-    ? true // no filter
-    : typeof options.filter === 'function'
-      ? options.filter(source) // filter is function
-      : options.filter.test(source) // filter is regex
+  const passesFilter =
+    options?.filter === undefined
+      ? true // no filter
+      : typeof options.filter === "function"
+        ? options.filter(source) // filter is function
+        : options.filter.test(source); // filter is regex
 
   if (!passesFilter) {
-    return
+    return;
   }
 
-  if(lstatSync(source).isDirectory()) {
+  if (lstatSync(source).isDirectory()) {
     const subPaths = readdirSync(source);
     await Promise.all(
       subPaths.map(async subPath => {
         const sourceSubpath = path.join(source, subPath);
-        const isSubPathAFolder = lstatSync(sourceSubpath).isDirectory()
-        const destSubPath = path.join(destination, subPath)
-        const existsDestSubPath = existsSync(destSubPath)
+        const isSubPathAFolder = lstatSync(sourceSubpath).isDirectory();
+        const destSubPath = path.join(destination, subPath);
+        const existsDestSubPath = existsSync(destSubPath);
         if (isSubPathAFolder && !existsDestSubPath) {
-          await mkdir(destSubPath)
+          await mkdir(destSubPath);
         }
-        await linkRecursive(sourceSubpath, destSubPath, options)
-      })
-    )
-    return
+        await linkRecursive(sourceSubpath, destSubPath, options);
+      }),
+    );
+    return;
   }
 
-  return link(source, destination)
-}
+  return link(source, destination);
+};
 
-export default linkRecursive
+export default linkRecursive;

--- a/src/utils/merge-package-json.ts
+++ b/src/utils/merge-package-json.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error We don't have types for this probably add .d.ts file
 import mergeJsonStr from "merge-packages";
 import fs from "fs";
 

--- a/src/utils/merge-package-json.ts
+++ b/src/utils/merge-package-json.ts
@@ -2,29 +2,22 @@
 import mergeJsonStr from "merge-packages";
 import fs from "fs";
 
-export function mergePackageJson(
-  targetPackageJsonPath: string,
-  secondPackageJsonPath: string,
-  isDev: boolean
-) {
+export function mergePackageJson(targetPackageJsonPath: string, secondPackageJsonPath: string, isDev: boolean) {
   const existsTarget = fs.existsSync(targetPackageJsonPath);
   const existsSecond = fs.existsSync(secondPackageJsonPath);
   if (!existsTarget && !existsSecond) {
     return;
   }
 
-  const targetPackageJson = existsTarget ? fs.readFileSync(targetPackageJsonPath, "utf8") : '{}';
+  const targetPackageJson = existsTarget ? fs.readFileSync(targetPackageJsonPath, "utf8") : "{}";
 
-  const secondPackageJson = existsSecond ? fs.readFileSync(secondPackageJsonPath, "utf8") : '{}';
+  const secondPackageJson = existsSecond ? fs.readFileSync(secondPackageJsonPath, "utf8") : "{}";
 
-  const mergedPkgStr = mergeJsonStr.default(
-    targetPackageJson,
-    secondPackageJson
-  );
+  const mergedPkgStr = mergeJsonStr.default(targetPackageJson, secondPackageJson);
 
   fs.writeFileSync(targetPackageJsonPath, mergedPkgStr, "utf8");
   if (isDev) {
-    const devStr = `TODO: write relevant information for the contributor`
+    const devStr = `TODO: write relevant information for the contributor`;
     fs.writeFileSync(`${targetPackageJsonPath}.dev`, devStr, "utf8");
   }
 }

--- a/src/utils/parse-arguments-into-options.ts
+++ b/src/utils/parse-arguments-into-options.ts
@@ -4,22 +4,20 @@ import * as https from "https";
 import { getDataFromExternalExtensionArgument } from "./external-extensions";
 import chalk from "chalk";
 
-const validateTemplate = async (
-  template: string
-): Promise<{ repository: string; branch?: string }> => {
+const validateTemplate = async (template: string): Promise<{ repository: string; branch?: string }> => {
   const { githubUrl, githubBranchUrl, branch } = getDataFromExternalExtensionArgument(template);
 
   // Check if repository exists
   await new Promise((resolve, reject) => {
     https
-      .get(githubBranchUrl, (res) => {
+      .get(githubBranchUrl, res => {
         if (res.statusCode !== 200) {
           reject(new Error(`Template not found: ${githubUrl}`));
         } else {
           resolve(null);
         }
       })
-      .on("error", (err) => {
+      .on("error", err => {
         reject(err);
       });
   });
@@ -28,9 +26,7 @@ const validateTemplate = async (
 };
 
 // TODO update smartContractFramework code with general extensions
-export async function parseArgumentsIntoOptions(
-  rawArgs: Args
-): Promise<RawOptions> {
+export async function parseArgumentsIntoOptions(rawArgs: Args): Promise<RawOptions> {
   const args = arg(
     {
       "--install": Boolean,
@@ -46,8 +42,8 @@ export async function parseArgumentsIntoOptions(
       "-e": "--extension",
     },
     {
-      argv: rawArgs.slice(2).map((a) => a.toLowerCase()),
-    }
+      argv: rawArgs.slice(2).map(a => a.toLowerCase()),
+    },
   );
 
   const install = args["--install"] ?? null;
@@ -60,12 +56,14 @@ export async function parseArgumentsIntoOptions(
 
   // ToDo. Allow multiple
   // ToDo. Allow core extensions too
-  const extension = args["--extension"]
-    ? await validateTemplate(args["--extension"])
-    : null;
+  const extension = args["--extension"] ? await validateTemplate(args["--extension"]) : null;
 
   if (extension) {
-    console.log(chalk.yellow(` You are using a third-party extension. Make sure you trust the source of ${chalk.yellow.bold(extension.repository)}\n`));
+    console.log(
+      chalk.yellow(
+        ` You are using a third-party extension. Make sure you trust the source of ${chalk.yellow.bold(extension.repository)}\n`,
+      ),
+    );
   }
 
   return {

--- a/src/utils/prompt-for-missing-options.ts
+++ b/src/utils/prompt-for-missing-options.ts
@@ -27,7 +27,7 @@ const nullExtensionChoice = {
 };
 
 export async function promptForMissingOptions(options: RawOptions): Promise<Options> {
-  const cliAnswers = Object.fromEntries(Object.entries(options).filter(([key, value]) => value !== null));
+  const cliAnswers = Object.fromEntries(Object.entries(options).filter(([, value]) => value !== null));
   const questions = [];
 
   questions.push({

--- a/src/utils/prompt-for-missing-options.ts
+++ b/src/utils/prompt-for-missing-options.ts
@@ -26,12 +26,8 @@ const nullExtensionChoice = {
   value: null,
 };
 
-export async function promptForMissingOptions(
-  options: RawOptions
-): Promise<Options> {
-  const cliAnswers = Object.fromEntries(
-    Object.entries(options).filter(([key, value]) => value !== null)
-  );
+export async function promptForMissingOptions(options: RawOptions): Promise<Options> {
+  const cliAnswers = Object.fromEntries(Object.entries(options).filter(([key, value]) => value !== null));
   const questions = [];
 
   questions.push({
@@ -42,14 +38,9 @@ export async function promptForMissingOptions(
     validate: (value: string) => value.length > 0,
   });
 
-  const recurringAddFollowUps = (
-    extensions: ExtensionDescriptor[],
-    relatedQuestion: string
-  ) => {
-    extensions.filter(extensionWithSubextensions).forEach((ext) => {
-      const nestedExtensions = ext.extensions.map(
-        (nestedExt) => extensionDict[nestedExt]
-      );
+  const recurringAddFollowUps = (extensions: ExtensionDescriptor[], relatedQuestion: string) => {
+    extensions.filter(extensionWithSubextensions).forEach(ext => {
+      const nestedExtensions = ext.extensions.map(nestedExt => extensionDict[nestedExt]);
       questions.push({
         // INFO: assuming nested extensions are all optional. To change this,
         // update ExtensionDescriptor adding type, and update code here.
@@ -60,28 +51,24 @@ export async function promptForMissingOptions(
         when: (answers: Answers) => {
           const relatedResponse = answers[relatedQuestion];
           const wasMultiselectResponse = Array.isArray(relatedResponse);
-          return wasMultiselectResponse
-            ? relatedResponse.includes(ext.value)
-            : relatedResponse === ext.value;
+          return wasMultiselectResponse ? relatedResponse.includes(ext.value) : relatedResponse === ext.value;
         },
       });
       recurringAddFollowUps(nestedExtensions, `${ext.value}-extensions`);
     });
   };
 
-  config.questions.forEach((question) => {
+  config.questions.forEach(question => {
     if (invalidQuestionNames.includes(question.name)) {
       throw new Error(
-        `The name of the question can't be "${
-          question.name
-        }". The invalid names are: ${invalidQuestionNames
-          .map((w) => `"${w}"`)
-          .join(", ")}`
+        `The name of the question can't be "${question.name}". The invalid names are: ${invalidQuestionNames
+          .map(w => `"${w}"`)
+          .join(", ")}`,
       );
     }
     const extensions = question.extensions
       .filter(isExtension)
-      .map((ext) => extensionDict[ext])
+      .map(ext => extensionDict[ext])
       .filter(isDefined);
 
     const hasNoneOption = question.extensions.includes(null);
@@ -90,9 +77,7 @@ export async function promptForMissingOptions(
       type: question.type === "multi-select" ? "checkbox" : "list",
       name: question.name,
       message: question.message,
-      choices: hasNoneOption
-        ? [...extensions, nullExtensionChoice]
-        : extensions,
+      choices: hasNoneOption ? [...extensions, nullExtensionChoice] : extensions,
     });
 
     recurringAddFollowUps(extensions, question.name);
@@ -115,14 +100,14 @@ export async function promptForMissingOptions(
     externalExtension: options.externalExtension,
   };
 
-  config.questions.forEach((question) => {
+  config.questions.forEach(question => {
     const { name } = question;
     const choice: Extension[] = [answers[name]].flat().filter(isDefined);
     mergedOptions.extensions.push(...choice);
   });
 
   const recurringAddNestedExtensions = (baseExtensions: Extension[]) => {
-    baseExtensions.forEach((extValue) => {
+    baseExtensions.forEach(extValue => {
       const nestedExtKey = `${extValue}-extensions`;
       const nestedExtensions = answers[nestedExtKey];
       if (nestedExtensions) {

--- a/src/utils/render-outro-message.ts
+++ b/src/utils/render-outro-message.ts
@@ -12,10 +12,7 @@ export async function renderOutroMessage(options: Options) {
   ${chalk.dim("cd")} ${options.project}
   `;
 
-  if (
-    options.extensions.includes("hardhat") ||
-    options.extensions.includes("foundry")
-  ) {
+  if (options.extensions.includes("hardhat") || options.extensions.includes("foundry")) {
     message += `
     \t${chalk.bold("Start the local development node")}
     \t${chalk.dim("yarn")} chain
@@ -26,9 +23,7 @@ export async function renderOutroMessage(options: Options) {
         await execa("foundryup", ["-h"]);
       } catch (error) {
         message += `
-      \t${chalk.bold.yellow(
-        "(NOTE: Foundryup is not installed in your system)"
-      )}
+      \t${chalk.bold.yellow("(NOTE: Foundryup is not installed in your system)")}
       \t${chalk.dim("Checkout: https://getfoundry.sh")}
       `;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,6 +834,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-escapes@npm:^6.2.0":
+  version: 6.2.1
+  resolution: "ansi-escapes@npm:6.2.1"
+  checksum: 4bdbabe0782a1d4007157798f8acab745d1d5e440c872e6792880d08025e0baababa6b85b36846e955fde7d1e4bf572cdb1fddf109de196e9388d7a1c55ce30d
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^2.0.0":
   version: 2.1.1
   resolution: "ansi-regex@npm:2.1.1"
@@ -887,7 +894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^6.1.0":
+"ansi-styles@npm:^6.0.0, ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1":
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: ef940f2f0ced1a6347398da88a91da7930c33ecac3c77b72c5905f8b8fe402c52e6fde304ff5347f616e27a742da3f1dc76de98f6866c69251ad0b07a66776d9
@@ -1067,6 +1074,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"braces@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "braces@npm:3.0.3"
+  dependencies:
+    fill-range: ^7.1.1
+  checksum: b95aa0b3bd909f6cd1720ffcf031aeaf46154dd88b4da01f9a1d3f7ea866a79eba76a6d01cbc3c422b2ee5cdc39a4f02491058d5df0d7bf6e6a162a832df1f69
+  languageName: node
+  linkType: hard
+
 "breakword@npm:^1.0.5":
   version: 1.0.6
   resolution: "breakword@npm:1.0.6"
@@ -1160,6 +1176,13 @@ __metadata:
   version: 5.2.0
   resolution: "chalk@npm:5.2.0"
   checksum: 03d8060277de6cf2fd567dc25fcf770593eb5bb85f460ce443e49255a30ff1242edd0c90a06a03803b0466ff0687a939b41db1757bec987113e83de89a003caa
+  languageName: node
+  linkType: hard
+
+"chalk@npm:5.3.0":
+  version: 5.3.0
+  resolution: "chalk@npm:5.3.0"
+  checksum: 623922e077b7d1e9dedaea6f8b9e9352921f8ae3afe739132e0e00c275971bdd331268183b2628cf4ab1727c45ea1f28d7e24ac23ce1db1eb653c414ca8a5a80
   languageName: node
   linkType: hard
 
@@ -1260,6 +1283,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-truncate@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "cli-truncate@npm:4.0.0"
+  dependencies:
+    slice-ansi: ^5.0.0
+    string-width: ^7.0.0
+  checksum: d5149175fd25ca985731bdeec46a55ec237475cf74c1a5e103baea696aceb45e372ac4acbaabf1316f06bd62e348123060f8191ffadfeedebd2a70a2a7fb199d
+  languageName: node
+  linkType: hard
+
 "cli-width@npm:^4.0.0":
   version: 4.0.0
   resolution: "cli-width@npm:4.0.0"
@@ -1344,6 +1377,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"colorette@npm:^2.0.20":
+  version: 2.0.20
+  resolution: "colorette@npm:2.0.20"
+  checksum: 0c016fea2b91b733eb9f4bcdb580018f52c0bc0979443dad930e5037a968237ac53d9beb98e218d2e9235834f8eebce7f8e080422d6194e957454255bde71d3d
+  languageName: node
+  linkType: hard
+
+"commander@npm:12.1.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 68e9818b00fc1ed9cdab9eb16905551c2b768a317ae69a5e3c43924c2b20ac9bb65b27e1cab36aeda7b6496376d4da908996ba2c0b5d79463e0fb1e77935d514
+  languageName: node
+  linkType: hard
+
 "commander@npm:^7.2.0":
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
@@ -1383,7 +1430,9 @@ __metadata:
     eslint-plugin-prettier: ^5.1.3
     execa: 7.1.1
     handlebars: ^4.7.7
+    husky: ^9.0.11
     inquirer: 9.2.0
+    lint-staged: ^15.2.4
     listr: 0.14.3
     merge-packages: ^0.1.6
     ncp: 2.0.0
@@ -1474,7 +1523,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -1577,6 +1626,13 @@ __metadata:
   version: 1.0.1
   resolution: "elegant-spinner@npm:1.0.1"
   checksum: d6a773d950c5d403b5f0fa402787e37dde99989ab6c943558fe8491cf7cd0df0e2747a9ff4d391d5a5f20a447cc9e9a63bdc956354ba47bea462f1603a5b04fe
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "emoji-regex@npm:10.3.0"
+  checksum: 5da48edfeb9462fb1ae5495cff2d79129974c696853fb0ce952cbf560f29a2756825433bf51cfd5157ec7b9f93f46f31d712e896d63e3d8ac9c3832bdb45ab73
   languageName: node
   linkType: hard
 
@@ -1910,6 +1966,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eventemitter3@npm:5.0.1"
+  checksum: 543d6c858ab699303c3c32e0f0f47fc64d360bf73c3daf0ac0b5079710e340d6fe9f15487f94e66c629f5f82cd1a8678d692f3dbb6f6fcd1190e1b97fcad36f8
+  languageName: node
+  linkType: hard
+
 "execa@npm:7.1.1":
   version: 7.1.1
   resolution: "execa@npm:7.1.1"
@@ -1924,6 +1987,23 @@ __metadata:
     signal-exit: ^3.0.7
     strip-final-newline: ^3.0.0
   checksum: 21fa46fc69314ace4068cf820142bdde5b643a5d89831c2c9349479c1555bff137a291b8e749e7efca36535e4e0a8c772c11008ca2e84d2cbd6ca141a3c8f937
+  languageName: node
+  linkType: hard
+
+"execa@npm:8.0.1":
+  version: 8.0.1
+  resolution: "execa@npm:8.0.1"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^8.0.1
+    human-signals: ^5.0.0
+    is-stream: ^3.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^5.1.0
+    onetime: ^6.0.0
+    signal-exit: ^4.1.0
+    strip-final-newline: ^3.0.0
+  checksum: cac1bf86589d1d9b73bdc5dda65c52012d1a9619c44c526891956745f7b366ca2603d29fe3f7460bacc2b48c6eab5d6a4f7afe0534b31473d3708d1265545e1f
   languageName: node
   linkType: hard
 
@@ -2067,6 +2147,15 @@ __metadata:
   dependencies:
     to-regex-range: ^5.0.1
   checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
+  languageName: node
+  linkType: hard
+
+"fill-range@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "fill-range@npm:7.1.1"
+  dependencies:
+    to-regex-range: ^5.0.1
+  checksum: b4abfbca3839a3d55e4ae5ec62e131e2e356bf4859ce8480c64c4876100f4df292a63e5bb1618e1d7460282ca2b305653064f01654474aa35c68000980f17798
   languageName: node
   linkType: hard
 
@@ -2244,6 +2333,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-east-asian-width@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "get-east-asian-width@npm:1.2.0"
+  checksum: ea55f4d4a42c4b00d3d9be3111bc17eb0161f60ed23fc257c1390323bb780a592d7a8bdd550260fd4627dabee9a118cdfa3475ae54edca35ebcd3bdae04179e3
+  languageName: node
+  linkType: hard
+
 "get-intrinsic@npm:^1.0.2, get-intrinsic@npm:^1.1.1, get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.0, get-intrinsic@npm:^1.2.1":
   version: 1.2.1
   resolution: "get-intrinsic@npm:1.2.1"
@@ -2269,6 +2365,13 @@ __metadata:
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "get-stream@npm:8.0.1"
+  checksum: 01e3d3cf29e1393f05f44d2f00445c5f9ec3d1c49e8179b31795484b9c117f4c695e5e07b88b50785d5c8248a788c85d9913a79266fc77e3ef11f78f10f1b974
   languageName: node
   linkType: hard
 
@@ -2562,12 +2665,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"human-signals@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "human-signals@npm:5.0.0"
+  checksum: 6504560d5ed91444f16bea3bd9dfc66110a339442084e56c3e7fa7bbdf3f406426d6563d662bdce67064b165eac31eeabfc0857ed170aaa612cf14ec9f9a464c
+  languageName: node
+  linkType: hard
+
 "humanize-ms@npm:^1.2.1":
   version: 1.2.1
   resolution: "humanize-ms@npm:1.2.1"
   dependencies:
     ms: ^2.0.0
   checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"husky@npm:^9.0.11":
+  version: 9.0.11
+  resolution: "husky@npm:9.0.11"
+  bin:
+    husky: bin.mjs
+  checksum: 1aebc3334dc7ac6288ff5e1fb72cfb447cfa474e72cf7ba692e8c5698c573ab725c28c6a5088c9f8e6aca5f47d40fa7261beffbc07a4d307ca21656dc4571f07
   languageName: node
   linkType: hard
 
@@ -2806,6 +2925,22 @@ __metadata:
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
   checksum: 44a30c29457c7fb8f00297bce733f0a64cd22eca270f83e58c105e0d015e45c019491a4ab2faef91ab51d4738c670daff901c799f6a700e27f7314029e99e348
+  languageName: node
+  linkType: hard
+
+"is-fullwidth-code-point@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-fullwidth-code-point@npm:4.0.0"
+  checksum: 8ae89bf5057bdf4f57b346fb6c55e9c3dd2549983d54191d722d5c739397a903012cc41a04ee3403fd872e811243ef91a7c5196da7b5841dc6b6aae31a264a8d
+  languageName: node
+  linkType: hard
+
+"is-fullwidth-code-point@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-fullwidth-code-point@npm:5.0.0"
+  dependencies:
+    get-east-asian-width: ^1.0.0
+  checksum: 8dfb2d2831b9e87983c136f5c335cd9d14c1402973e357a8ff057904612ed84b8cba196319fabedf9aefe4639e14fe3afe9d9966d1d006ebeb40fe1fed4babe5
   languageName: node
   linkType: hard
 
@@ -3128,10 +3263,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lilconfig@npm:3.1.1":
+  version: 3.1.1
+  resolution: "lilconfig@npm:3.1.1"
+  checksum: dc8a4f4afde3f0fac6bd36163cc4777a577a90759b8ef1d0d766b19ccf121f723aa79924f32af5b954f3965268215e046d0f237c41c76e5ef01d4e6d1208a15e
+  languageName: node
+  linkType: hard
+
 "lines-and-columns@npm:^1.1.6":
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
   checksum: 0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
+  languageName: node
+  linkType: hard
+
+"lint-staged@npm:^15.2.4":
+  version: 15.2.4
+  resolution: "lint-staged@npm:15.2.4"
+  dependencies:
+    chalk: 5.3.0
+    commander: 12.1.0
+    debug: 4.3.4
+    execa: 8.0.1
+    lilconfig: 3.1.1
+    listr2: 8.2.1
+    micromatch: 4.0.6
+    pidtree: 0.6.0
+    string-argv: 0.3.2
+    yaml: 2.4.2
+  bin:
+    lint-staged: bin/lint-staged.js
+  checksum: 521a5cd3c5e381f74bea87d38c2bb194dd89ebab85470e0c49a79d10333f858bb7141744b9ff9e01ebac2a02b22f39933bcc7739d965e9e8ba50fe900ca4d250
   languageName: node
   linkType: hard
 
@@ -3169,6 +3331,20 @@ __metadata:
     date-fns: ^1.27.2
     figures: ^2.0.0
   checksum: 3e504be729f9dd15b40db743e403673b76331774411dbc29d6f48136f6ba8bc1dee645a4e621c1cb781e6e69a58b78cb9aa8c153c7ceccfe4e4ea74d563bca3a
+  languageName: node
+  linkType: hard
+
+"listr2@npm:8.2.1":
+  version: 8.2.1
+  resolution: "listr2@npm:8.2.1"
+  dependencies:
+    cli-truncate: ^4.0.0
+    colorette: ^2.0.20
+    eventemitter3: ^5.0.1
+    log-update: ^6.0.0
+    rfdc: ^1.3.1
+    wrap-ansi: ^9.0.0
+  checksum: a37c032850fc01f45cf6144f2b66d0c56a596b708de1acbd52e7c396a2eb188d027ad132c93a0ad946d7932a581dfcfc2e4318bb301926b01877cb4903d09fbd
   languageName: node
   linkType: hard
 
@@ -3279,6 +3455,19 @@ __metadata:
     cli-cursor: ^2.0.0
     wrap-ansi: ^3.0.1
   checksum: 84fd8e93bfc316eb6ca479a37743f2edcb7563fe5b9161205ce2980f0b3c822717b8f8f1871369697fcb0208521d7b8d00750c594edc3f8a8273dd8b48dd14a3
+  languageName: node
+  linkType: hard
+
+"log-update@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "log-update@npm:6.0.0"
+  dependencies:
+    ansi-escapes: ^6.2.0
+    cli-cursor: ^4.0.0
+    slice-ansi: ^7.0.0
+    strip-ansi: ^7.1.0
+    wrap-ansi: ^9.0.0
+  checksum: 8803ceba2fb28626951b85de598c8d5a4f5e39f1f767cc54fd925412cc7780ba89ce1dbec24dc96fa46f89d226e1ae984534aa729dc9c9b734e36bb805428ffa
   languageName: node
   linkType: hard
 
@@ -3394,6 +3583,16 @@ __metadata:
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
+  languageName: node
+  linkType: hard
+
+"micromatch@npm:4.0.6":
+  version: 4.0.6
+  resolution: "micromatch@npm:4.0.6"
+  dependencies:
+    braces: ^3.0.3
+    picomatch: ^4.0.2
+  checksum: cd44a850c638d82232608e2a03677c5828b9faf35bacfd4817ae232208e2a56bac97bceb67da6a5d4d5a603c1cc88f65ecae3af6be11b5a8c10c995515231e78
   languageName: node
   linkType: hard
 
@@ -3996,6 +4195,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "picomatch@npm:4.0.2"
+  checksum: a7a5188c954f82c6585720e9143297ccd0e35ad8072231608086ca950bee672d51b0ef676254af0788205e59bd4e4deb4e7708769226bed725bf13370a7d1464
+  languageName: node
+  linkType: hard
+
+"pidtree@npm:0.6.0":
+  version: 0.6.0
+  resolution: "pidtree@npm:0.6.0"
+  bin:
+    pidtree: bin/pidtree.js
+  checksum: 8fbc073ede9209dd15e80d616e65eb674986c93be49f42d9ddde8dbbd141bb53d628a7ca4e58ab5c370bb00383f67d75df59a9a226dede8fa801267a7030c27a
+  languageName: node
+  linkType: hard
+
 "pify@npm:^3.0.0":
   version: 3.0.0
   resolution: "pify@npm:3.0.0"
@@ -4311,6 +4526,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rfdc@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "rfdc@npm:1.3.1"
+  checksum: d5d1e930aeac7e0e0a485f97db1356e388bdbeff34906d206fe524dd5ada76e95f186944d2e68307183fdc39a54928d4426bbb6734851692cfe9195efba58b79
+  languageName: node
+  linkType: hard
+
 "rimraf@npm:^3.0.2":
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
@@ -4534,6 +4756,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"signal-exit@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "signal-exit@npm:4.1.0"
+  checksum: 64c757b498cb8629ffa5f75485340594d2f8189e9b08700e69199069c8e3070fb3e255f7ab873c05dc0b3cec412aea7402e10a5990cb6a050bd33ba062a6c549
+  languageName: node
+  linkType: hard
+
 "slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -4545,6 +4774,26 @@ __metadata:
   version: 0.0.4
   resolution: "slice-ansi@npm:0.0.4"
   checksum: 481d969c6aa771b27d7baacd6fe321751a0b9eb410274bda10ca81ea641bbfe747e428025d6d8f15bd635fdcfd57e8b2d54681ee6b0ce0c40f78644b144759e3
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "slice-ansi@npm:5.0.0"
+  dependencies:
+    ansi-styles: ^6.0.0
+    is-fullwidth-code-point: ^4.0.0
+  checksum: 7e600a2a55e333a21ef5214b987c8358fe28bfb03c2867ff2cbf919d62143d1812ac27b4297a077fdaf27a03da3678e49551c93e35f9498a3d90221908a1180e
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "slice-ansi@npm:7.1.0"
+  dependencies:
+    ansi-styles: ^6.2.1
+    is-fullwidth-code-point: ^5.0.0
+  checksum: 10313dd3cf7a2e4b265f527b1684c7c568210b09743fd1bd74f2194715ed13ffba653dc93a5fa79e3b1711518b8990a732cb7143aa01ddafe626e99dfa6474b2
   languageName: node
   linkType: hard
 
@@ -4700,6 +4949,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-argv@npm:0.3.2":
+  version: 0.3.2
+  resolution: "string-argv@npm:0.3.2"
+  checksum: 8703ad3f3db0b2641ed2adbb15cf24d3945070d9a751f9e74a924966db9f325ac755169007233e8985a39a6a292f14d4fee20482989b89b96e473c4221508a0f
+  languageName: node
+  linkType: hard
+
 "string-width@npm:^1.0.1":
   version: 1.0.2
   resolution: "string-width@npm:1.0.2"
@@ -4740,6 +4996,17 @@ __metadata:
     emoji-regex: ^9.2.2
     strip-ansi: ^7.0.1
   checksum: 7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "string-width@npm:7.1.0"
+  dependencies:
+    emoji-regex: ^10.3.0
+    get-east-asian-width: ^1.0.0
+    strip-ansi: ^7.1.0
+  checksum: a183573fe7209e0d294f661846d33f8caf72aa86d983e5b48a0ed45ab15bcccb02c6f0344b58b571988871105457137b8207855ea536827dbc4a376a0f31bf8f
   languageName: node
   linkType: hard
 
@@ -4818,6 +5085,15 @@ __metadata:
   dependencies:
     ansi-regex: ^6.0.1
   checksum: 257f78fa433520e7f9897722731d78599cb3fce29ff26a20a5e12ba4957463b50a01136f37c43707f4951817a75e90820174853d6ccc240997adc5df8f966039
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "strip-ansi@npm:7.1.0"
+  dependencies:
+    ansi-regex: ^6.0.1
+  checksum: 859c73fcf27869c22a4e4d8c6acfe690064659e84bef9458aa6d13719d09ca88dcfd40cbf31fd0be63518ea1a643fe070b4827d353e09533a5b0b9fd4553d64d
   languageName: node
   linkType: hard
 
@@ -5353,6 +5629,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "wrap-ansi@npm:9.0.0"
+  dependencies:
+    ansi-styles: ^6.2.1
+    string-width: ^7.0.0
+    strip-ansi: ^7.1.0
+  checksum: b2d43b76b3d8dcbdd64768165e548aad3e54e1cae4ecd31bac9966faaa7cf0b0345677ad6879db10ba58eb446ba8fa44fb82b4951872fd397f096712467a809f
+  languageName: node
+  linkType: hard
+
 "wrappy@npm:1":
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
@@ -5385,6 +5672,15 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
+"yaml@npm:2.4.2":
+  version: 2.4.2
+  resolution: "yaml@npm:2.4.2"
+  bin:
+    yaml: bin.mjs
+  checksum: 90dda4485de04367251face9abb5c36927c94e44078f4e958e6468a07e74e7e92f89be20fc49860b6268c51ee5a5fc79ef89197d3f874bf24ef8921cc4ba9013
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,6 +1141,7 @@ __metadata:
     merge-packages: ^0.1.6
     ncp: 2.0.0
     pkg-install: 1.0.0
+    prettier: 3.2.5
     rollup: 3.21.0
     rollup-plugin-auto-external: 2.0.0
     tslib: 2.5.0
@@ -3436,6 +3437,15 @@ __metadata:
     path-exists: ^4.0.0
     which-pm: 2.0.0
   checksum: 0de0948cb6ae22213f2ad7868032d89f1e1443d9caabc22ceeb9d284f19d359d65b67fab178f4db5c8c6ca6ae34642bdc72730b70ab1899ea158e2677a88a6d0
+  languageName: node
+  linkType: hard
+
+"prettier@npm:3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,10 +278,84 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "@eslint-community/eslint-utils@npm:4.4.0"
+  dependencies:
+    eslint-visitor-keys: ^3.3.0
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: cdfe3ae42b4f572cbfb46d20edafe6f36fc5fb52bf2d90875c58aefe226892b9677fef60820e2832caf864a326fe4fc225714c46e8389ccca04d5f9288aabd22
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.10.0, @eslint-community/regexpp@npm:^4.6.1":
+  version: 4.10.0
+  resolution: "@eslint-community/regexpp@npm:4.10.0"
+  checksum: 2a6e345429ea8382aaaf3a61f865cae16ed44d31ca917910033c02dc00d505d939f10b81e079fa14d43b51499c640138e153b7e40743c4c094d9df97d4e56f7b
+  languageName: node
+  linkType: hard
+
+"@eslint/eslintrc@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@eslint/eslintrc@npm:3.1.0"
+  dependencies:
+    ajv: ^6.12.4
+    debug: ^4.3.2
+    espree: ^10.0.1
+    globals: ^14.0.0
+    ignore: ^5.2.0
+    import-fresh: ^3.2.1
+    js-yaml: ^4.1.0
+    minimatch: ^3.1.2
+    strip-json-comments: ^3.1.1
+  checksum: b0a9bbd98c8b9e0f4d975b042ff9b874dde722b20834ea2ff46551c3de740d4f10f56c449b790ef34d7f82147cbddfc22b004a43cc885dbc2664bb134766b5e4
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:9.3.0, @eslint/js@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "@eslint/js@npm:9.3.0"
+  checksum: 5af317c8bcfef660efc17624b825c71bac16770f8866bfdc2922e1fcc2010af96e4f896e91724b81550e5dba6db6983c221b5be9a1294c9e727dee9ada15c9f8
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
   checksum: 4059f790e2d07bf3c3ff3e0fec0daa8144fe35c1f6e0111c9921bd32106adaa97a4ab096ad7dab1e28ee6a9060083c4d1a4ada42a7f5f3f7a96b8812e2b757c1
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/config-array@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "@humanwhocodes/config-array@npm:0.13.0"
+  dependencies:
+    "@humanwhocodes/object-schema": ^2.0.3
+    debug: ^4.3.1
+    minimatch: ^3.0.5
+  checksum: eae69ff9134025dd2924f0b430eb324981494be26f0fddd267a33c28711c4db643242cf9fddf7dadb9d16c96b54b2d2c073e60a56477df86e0173149313bd5d6
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/module-importer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@humanwhocodes/module-importer@npm:1.0.1"
+  checksum: 0fd22007db8034a2cdf2c764b140d37d9020bbfce8a49d3ec5c05290e77d4b0263b1b972b752df8c89e5eaa94073408f2b7d977aed131faf6cf396ebb5d7fb61
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/object-schema@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@humanwhocodes/object-schema@npm:2.0.3"
+  checksum: d3b78f6c5831888c6ecc899df0d03bcc25d46f3ad26a11d7ea52944dc36a35ef543fad965322174238d677a43d5c694434f6607532cff7077062513ad7022631
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/retry@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@humanwhocodes/retry@npm:0.3.0"
+  checksum: 4349cb8b60466a000e945fde8f8551cefb01ebba22ead4a92ac7b145f67f5da6b52e5a1e0c53185d732d0a49958ac29327934a4a5ac1d0bc20efb4429a4f7bf7
   languageName: node
   linkType: hard
 
@@ -328,7 +402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodelib/fs.walk@npm:^1.2.3":
+"@nodelib/fs.walk@npm:^1.2.3, @nodelib/fs.walk@npm:^1.2.8":
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
@@ -355,6 +429,13 @@ __metadata:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
   checksum: 52dc02259d98da517fae4cb3a0a3850227bdae4939dda1980b788a7670636ca2b4a01b58df03dd5f65c1e3cb70c50fa8ce5762b582b3f499ec30ee5ce1fd9380
+  languageName: node
+  linkType: hard
+
+"@pkgr/core@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "@pkgr/core@npm:0.1.1"
+  checksum: 6f25fd2e3008f259c77207ac9915b02f1628420403b2630c92a07ff963129238c9262afc9e84344c7a23b5cc1f3965e2cd17e3798219f5fd78a63d144d3cceba
   languageName: node
   linkType: hard
 
@@ -536,6 +617,124 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:7.10.0":
+  version: 7.10.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:7.10.0"
+  dependencies:
+    "@eslint-community/regexpp": ^4.10.0
+    "@typescript-eslint/scope-manager": 7.10.0
+    "@typescript-eslint/type-utils": 7.10.0
+    "@typescript-eslint/utils": 7.10.0
+    "@typescript-eslint/visitor-keys": 7.10.0
+    graphemer: ^1.4.0
+    ignore: ^5.3.1
+    natural-compare: ^1.4.0
+    ts-api-utils: ^1.3.0
+  peerDependencies:
+    "@typescript-eslint/parser": ^7.0.0
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 8cef558bb3e5a3f97289ae1cbfc7d65e2fa2a3ff77f5c08f250162790a5df1daff03d72f2cde75b8ef0bb3216376cc8377430a911dae1e3e62f1cba646e7b5a4
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:7.10.0":
+  version: 7.10.0
+  resolution: "@typescript-eslint/parser@npm:7.10.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": 7.10.0
+    "@typescript-eslint/types": 7.10.0
+    "@typescript-eslint/typescript-estree": 7.10.0
+    "@typescript-eslint/visitor-keys": 7.10.0
+    debug: ^4.3.4
+  peerDependencies:
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 68a30e03f77e8cb58c6f7407d6b90befaa1c97cc3fc2d6b9b43f7003441f2c4ae50b14aaf9c2cb8b2c0e99175c5d753812b9d0a43fadaf8878cde92d82d86266
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:7.10.0":
+  version: 7.10.0
+  resolution: "@typescript-eslint/scope-manager@npm:7.10.0"
+  dependencies:
+    "@typescript-eslint/types": 7.10.0
+    "@typescript-eslint/visitor-keys": 7.10.0
+  checksum: 27a954c4655d649007103009d77a0c68038afa81b0199c1cb9f69632e29476a9c6ace2d4eb8ace64cc47d351d6dca8f497f99a71d9e0dc5d700986db57b28a65
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:7.10.0":
+  version: 7.10.0
+  resolution: "@typescript-eslint/type-utils@npm:7.10.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": 7.10.0
+    "@typescript-eslint/utils": 7.10.0
+    debug: ^4.3.4
+    ts-api-utils: ^1.3.0
+  peerDependencies:
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 1669e62e9f5a529ba6e93f6008d8a764cbba0605a9dc5e528a0853bf8025afe339f716ad588255c11166400c2b2e3310b8f6c630b3ce48b224f4a40c63b4d02a
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:7.10.0":
+  version: 7.10.0
+  resolution: "@typescript-eslint/types@npm:7.10.0"
+  checksum: 9a16c86e8ace5f38281d80895844e9a4d963887e1304d335ed4e66eefe6646f24d98485f242fe9ee592e870c675dcd92683918f536dd462e26eb45fa69f5e2a5
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:7.10.0":
+  version: 7.10.0
+  resolution: "@typescript-eslint/typescript-estree@npm:7.10.0"
+  dependencies:
+    "@typescript-eslint/types": 7.10.0
+    "@typescript-eslint/visitor-keys": 7.10.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    minimatch: ^9.0.4
+    semver: ^7.6.0
+    ts-api-utils: ^1.3.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 2d63d608dcc87aa96b6d1300eeb2eb94fb68b9168b3ce0a05b8256adb132fdd9217c8358d467fad3f5ec4dea25e266d161282da4d032d66e3ab6a62d7ece568d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:7.10.0":
+  version: 7.10.0
+  resolution: "@typescript-eslint/utils@npm:7.10.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.4.0
+    "@typescript-eslint/scope-manager": 7.10.0
+    "@typescript-eslint/types": 7.10.0
+    "@typescript-eslint/typescript-estree": 7.10.0
+  peerDependencies:
+    eslint: ^8.56.0
+  checksum: 5d0e9d8c06e3614c5001831813eb09d222c0160f77750f65c2d7fe39318f0586b4cb665734fb4b77c4179c082e109bb0ea6b399010be3f9a2d45a2e7f276a56b
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:7.10.0":
+  version: 7.10.0
+  resolution: "@typescript-eslint/visitor-keys@npm:7.10.0"
+  dependencies:
+    "@typescript-eslint/types": 7.10.0
+    eslint-visitor-keys: ^3.4.3
+  checksum: 19218120d1295a93b6ce5163f517180eb779c0c578e0f8320887a5816576c8a1497032c25d2d1b2abea345f5929e91cda2aab15aafd3c4a52d1c3aef8744d55a
+  languageName: node
+  linkType: hard
+
 "@voxpelli/semver-set@npm:^3.0.0":
   version: 3.0.0
   resolution: "@voxpelli/semver-set@npm:3.0.0"
@@ -549,6 +748,24 @@ __metadata:
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
   checksum: a4a97ec07d7ea112c517036882b2ac22f3109b7b19077dc656316d07d308438aac28e4d9746dc4d84bf6b1e75b4a7b0a5f3cb30592419f128ca9a8cee3bcfa17
+  languageName: node
+  linkType: hard
+
+"acorn-jsx@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "acorn-jsx@npm:5.3.2"
+  peerDependencies:
+    acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: c3d3b2a89c9a056b205b69530a37b972b404ee46ec8e5b341666f9513d3163e2a4f214a71f4dfc7370f5a9c07472d2fd1c11c91c3f03d093e37637d95da98950
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.11.3":
+  version: 8.11.3
+  resolution: "acorn@npm:8.11.3"
+  bin:
+    acorn: bin/acorn
+  checksum: 76d8e7d559512566b43ab4aadc374f11f563f0a9e21626dd59cb2888444e9445923ae9f3699972767f18af61df89cd89f5eaaf772d1327b055b45cb829b4a88c
   languageName: node
   linkType: hard
 
@@ -579,6 +796,18 @@ __metadata:
     clean-stack: ^2.0.0
     indent-string: ^4.0.0
   checksum: 1101a33f21baa27a2fa8e04b698271e64616b886795fd43c31068c07533c7b3facfcaf4e9e0cab3624bd88f729a592f1c901a1a229c9e490eafce411a8644b79
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^6.12.4":
+  version: 6.12.6
+  resolution: "ajv@npm:6.12.6"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    fast-json-stable-stringify: ^2.0.0
+    json-schema-traverse: ^0.4.1
+    uri-js: ^4.2.2
+  checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
   languageName: node
   linkType: hard
 
@@ -702,6 +931,13 @@ __metadata:
   dependencies:
     sprintf-js: ~1.0.2
   checksum: 7ca6e45583a28de7258e39e13d81e925cfa25d7d4aacbf806a382d3c02fcb13403a07fb8aeef949f10a7cfe4a62da0e2e807b348a5980554cc28ee573ef95945
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
   languageName: node
   linkType: hard
 
@@ -895,6 +1131,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"callsites@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "callsites@npm:3.1.0"
+  checksum: 072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
+  languageName: node
+  linkType: hard
+
 "camelcase-keys@npm:^6.2.2":
   version: 6.2.2
   resolution: "camelcase-keys@npm:6.2.2"
@@ -944,7 +1187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -1127,6 +1370,7 @@ __metadata:
   resolution: "create-eth@workspace:."
   dependencies:
     "@changesets/cli": ^2.26.2
+    "@eslint/js": ^9.3.0
     "@rollup/plugin-typescript": 11.1.0
     "@types/inquirer": 9.0.3
     "@types/listr": 0.14.4
@@ -1134,6 +1378,9 @@ __metadata:
     "@types/node": 18.16.0
     arg: 5.0.2
     chalk: 5.2.0
+    eslint: ^9.3.0
+    eslint-config-prettier: ^9.1.0
+    eslint-plugin-prettier: ^5.1.3
     execa: 7.1.1
     handlebars: ^4.7.7
     inquirer: 9.2.0
@@ -1146,6 +1393,7 @@ __metadata:
     rollup-plugin-auto-external: 2.0.0
     tslib: 2.5.0
     typescript: 5.0.4
+    typescript-eslint: ^7.10.0
   bin:
     create-eth: bin/create-dapp-se2.js
   languageName: unknown
@@ -1175,7 +1423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -1226,7 +1474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.3":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -1252,6 +1500,13 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
+  languageName: node
+  linkType: hard
+
+"deep-is@npm:^0.1.3":
+  version: 0.1.4
+  resolution: "deep-is@npm:0.1.4"
+  checksum: edb65dd0d7d1b9c40b2f50219aef30e116cedd6fc79290e740972c132c09106d2e80aa0bc8826673dd5a00222d4179c84b36a790eef63a4c4bca75a37ef90804
   languageName: node
   linkType: hard
 
@@ -1482,10 +1737,127 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "escape-string-regexp@npm:4.0.0"
+  checksum: 98b48897d93060f2322108bf29db0feba7dd774be96cd069458d1453347b25ce8682ecc39859d4bca2203cc0ab19c237bcc71755eff49a0f8d90beadeeba5cc5
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^5.0.0":
   version: 5.0.0
   resolution: "escape-string-regexp@npm:5.0.0"
   checksum: 20daabe197f3cb198ec28546deebcf24b3dbb1a5a269184381b3116d12f0532e06007f4bc8da25669d6a7f8efb68db0758df4cd981f57bc5b57f521a3e12c59e
+  languageName: node
+  linkType: hard
+
+"eslint-config-prettier@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "eslint-config-prettier@npm:9.1.0"
+  peerDependencies:
+    eslint: ">=7.0.0"
+  bin:
+    eslint-config-prettier: bin/cli.js
+  checksum: 9229b768c879f500ee54ca05925f31b0c0bafff3d9f5521f98ff05127356de78c81deb9365c86a5ec4efa990cb72b74df8612ae15965b14136044c73e1f6a907
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-prettier@npm:^5.1.3":
+  version: 5.1.3
+  resolution: "eslint-plugin-prettier@npm:5.1.3"
+  dependencies:
+    prettier-linter-helpers: ^1.0.0
+    synckit: ^0.8.6
+  peerDependencies:
+    "@types/eslint": ">=8.0.0"
+    eslint: ">=8.0.0"
+    eslint-config-prettier: "*"
+    prettier: ">=3.0.0"
+  peerDependenciesMeta:
+    "@types/eslint":
+      optional: true
+    eslint-config-prettier:
+      optional: true
+  checksum: eb2a7d46a1887e1b93788ee8f8eb81e0b6b2a6f5a66a62bc6f375b033fc4e7ca16448da99380be800042786e76cf5c0df9c87a51a2c9b960ed47acbd7c0b9381
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "eslint-scope@npm:8.0.1"
+  dependencies:
+    esrecurse: ^4.3.0
+    estraverse: ^5.2.0
+  checksum: 67a5a39312dadb8c9a677df0f2e8add8daf15280b08bfe07f898d5347ee2d7cd2a1f5c2760f34e46e8f5f13f7192f47c2c10abe676bfa4173ae5539365551940
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.3":
+  version: 3.4.3
+  resolution: "eslint-visitor-keys@npm:3.4.3"
+  checksum: 36e9ef87fca698b6fd7ca5ca35d7b2b6eeaaf106572e2f7fd31c12d3bfdaccdb587bba6d3621067e5aece31c8c3a348b93922ab8f7b2cbc6aaab5e1d89040c60
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "eslint-visitor-keys@npm:4.0.0"
+  checksum: 5c09f89cf29d87cdbfbac38802a880d3c2e65f8cb61c689888346758f1e24a4c7f6caefeac9474dfa52058a99920623599bdb00516976a30134abeba91275aa2
+  languageName: node
+  linkType: hard
+
+"eslint@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "eslint@npm:9.3.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.2.0
+    "@eslint-community/regexpp": ^4.6.1
+    "@eslint/eslintrc": ^3.1.0
+    "@eslint/js": 9.3.0
+    "@humanwhocodes/config-array": ^0.13.0
+    "@humanwhocodes/module-importer": ^1.0.1
+    "@humanwhocodes/retry": ^0.3.0
+    "@nodelib/fs.walk": ^1.2.8
+    ajv: ^6.12.4
+    chalk: ^4.0.0
+    cross-spawn: ^7.0.2
+    debug: ^4.3.2
+    escape-string-regexp: ^4.0.0
+    eslint-scope: ^8.0.1
+    eslint-visitor-keys: ^4.0.0
+    espree: ^10.0.1
+    esquery: ^1.4.2
+    esutils: ^2.0.2
+    fast-deep-equal: ^3.1.3
+    file-entry-cache: ^8.0.0
+    find-up: ^5.0.0
+    glob-parent: ^6.0.2
+    ignore: ^5.2.0
+    imurmurhash: ^0.1.4
+    is-glob: ^4.0.0
+    is-path-inside: ^3.0.3
+    json-stable-stringify-without-jsonify: ^1.0.1
+    levn: ^0.4.1
+    lodash.merge: ^4.6.2
+    minimatch: ^3.1.2
+    natural-compare: ^1.4.0
+    optionator: ^0.9.3
+    strip-ansi: ^6.0.1
+    text-table: ^0.2.0
+  bin:
+    eslint: bin/eslint.js
+  checksum: c6d1eb8b4b064470a99f0d927b0d2b88f1947d7e871761b43b84e6c9b6464db4f6ebbb868f7196a45d2589978b09919a8807d200e3b1640d0a9cd245c9504707
+  languageName: node
+  linkType: hard
+
+"espree@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "espree@npm:10.0.1"
+  dependencies:
+    acorn: ^8.11.3
+    acorn-jsx: ^5.3.2
+    eslint-visitor-keys: ^4.0.0
+  checksum: 62c9242a84c6741cebd35ede6574131d0419be7e5559566403e384087d99c4ddb2ced44e32acd44a4c3d8a8a84997cf8d78810c4e46b3fe25a804f1a92dc6b9d
   languageName: node
   linkType: hard
 
@@ -1499,10 +1871,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esquery@npm:^1.4.2":
+  version: 1.5.0
+  resolution: "esquery@npm:1.5.0"
+  dependencies:
+    estraverse: ^5.1.0
+  checksum: aefb0d2596c230118656cd4ec7532d447333a410a48834d80ea648b1e7b5c9bc9ed8b5e33a89cb04e487b60d622f44cf5713bf4abed7c97343edefdc84a35900
+  languageName: node
+  linkType: hard
+
+"esrecurse@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "esrecurse@npm:4.3.0"
+  dependencies:
+    estraverse: ^5.2.0
+  checksum: ebc17b1a33c51cef46fdc28b958994b1dc43cd2e86237515cbc3b4e5d2be6a811b2315d0a1a4d9d340b6d2308b15322f5c8291059521cc5f4802f65e7ec32837
+  languageName: node
+  linkType: hard
+
+"estraverse@npm:^5.1.0, estraverse@npm:^5.2.0":
+  version: 5.3.0
+  resolution: "estraverse@npm:5.3.0"
+  checksum: 072780882dc8416ad144f8fe199628d2b3e7bbc9989d9ed43795d2c90309a2047e6bc5979d7e2322a341163d22cfad9e21f4110597fe487519697389497e4e2b
+  languageName: node
+  linkType: hard
+
 "estree-walker@npm:^2.0.2":
   version: 2.0.2
   resolution: "estree-walker@npm:2.0.2"
   checksum: 6151e6f9828abe2259e57f5fd3761335bb0d2ebd76dc1a01048ccee22fabcfef3c0859300f6d83ff0d1927849368775ec5a6d265dde2f6de5a1be1721cd94efc
+  languageName: node
+  linkType: hard
+
+"esutils@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "esutils@npm:2.0.3"
+  checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
   languageName: node
   linkType: hard
 
@@ -1556,6 +1960,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "fast-deep-equal@npm:3.1.3"
+  checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
+  languageName: node
+  linkType: hard
+
+"fast-diff@npm:^1.1.2":
+  version: 1.3.0
+  resolution: "fast-diff@npm:1.3.0"
+  checksum: d22d371b994fdc8cce9ff510d7b8dc4da70ac327bcba20df607dd5b9cae9f908f4d1028f5fe467650f058d1e7270235ae0b8230809a262b4df587a3b3aa216c3
+  languageName: node
+  linkType: hard
+
 "fast-glob@npm:^3.0.3":
   version: 3.2.12
   resolution: "fast-glob@npm:3.2.12"
@@ -1579,6 +1997,20 @@ __metadata:
     merge2: ^1.3.0
     micromatch: ^4.0.4
   checksum: b6f3add6403e02cf3a798bfbb1183d0f6da2afd368f27456010c0bc1f9640aea308243d4cb2c0ab142f618276e65ecb8be1661d7c62a7b4e5ba774b9ce5432e5
+  languageName: node
+  linkType: hard
+
+"fast-json-stable-stringify@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "fast-json-stable-stringify@npm:2.1.0"
+  checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
+  languageName: node
+  linkType: hard
+
+"fast-levenshtein@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "fast-levenshtein@npm:2.0.6"
+  checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
   languageName: node
   linkType: hard
 
@@ -1620,6 +2052,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-entry-cache@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "file-entry-cache@npm:8.0.0"
+  dependencies:
+    flat-cache: ^4.0.0
+  checksum: f67802d3334809048c69b3d458f672e1b6d26daefda701761c81f203b80149c35dea04d78ea4238969dd617678e530876722a0634c43031a0957f10cc3ed190f
+  languageName: node
+  linkType: hard
+
 "fill-range@npm:^7.0.1":
   version: 7.0.1
   resolution: "fill-range@npm:7.0.1"
@@ -1656,6 +2097,23 @@ __metadata:
     micromatch: ^4.0.2
     pkg-dir: ^4.2.0
   checksum: b4abdd37ab87c2172e2abab69ecbfed365d63232742cd1f0a165020fba1b200478e944ec2035c6aaf0ae142ac4c523cbf08670f45e59b242bcc295731b017825
+  languageName: node
+  linkType: hard
+
+"flat-cache@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "flat-cache@npm:4.0.1"
+  dependencies:
+    flatted: ^3.2.9
+    keyv: ^4.5.4
+  checksum: 899fc86bf6df093547d76e7bfaeb900824b869d7d457d02e9b8aae24836f0a99fbad79328cfd6415ee8908f180699bf259dc7614f793447cb14f707caf5996f6
+  languageName: node
+  linkType: hard
+
+"flatted@npm:^3.2.9":
+  version: 3.3.1
+  resolution: "flatted@npm:3.3.1"
+  checksum: 85ae7181650bb728c221e7644cbc9f4bf28bc556f2fc89bb21266962bdf0ce1029cc7acc44bb646cd469d9baac7c317f64e841c4c4c00516afa97320cdac7f94
   languageName: node
   linkType: hard
 
@@ -1840,6 +2298,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob-parent@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "glob-parent@npm:6.0.2"
+  dependencies:
+    is-glob: ^4.0.3
+  checksum: c13ee97978bef4f55106b71e66428eb1512e71a7466ba49025fc2aec59a5bfb0954d5abd58fc5ee6c9b076eef4e1f6d3375c2e964b88466ca390da4419a786a8
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -1864,6 +2331,13 @@ __metadata:
     minimatch: ^5.0.1
     once: ^1.3.0
   checksum: 92fbea3221a7d12075f26f0227abac435de868dd0736a17170663783296d0dd8d3d532a5672b4488a439bf5d7fb85cdd07c11185d6cd39184f0385cbdfb86a47
+  languageName: node
+  linkType: hard
+
+"globals@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "globals@npm:14.0.0"
+  checksum: 534b8216736a5425737f59f6e6a5c7f386254560c9f41d24a9227d60ee3ad4a9e82c5b85def0e212e9d92162f83a92544be4c7fd4c902cb913736c10e08237ac
   languageName: node
   linkType: hard
 
@@ -1892,7 +2366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.0":
+"globby@npm:^11.0.0, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -1926,6 +2400,13 @@ __metadata:
   version: 1.0.4
   resolution: "grapheme-splitter@npm:1.0.4"
   checksum: 0c22ec54dee1b05cd480f78cf14f732cb5b108edc073572c4ec205df4cd63f30f8db8025afc5debc8835a8ddeacf648a1c7992fe3dcd6ad38f9a476d84906620
+  languageName: node
+  linkType: hard
+
+"graphemer@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "graphemer@npm:1.4.0"
+  checksum: bab8f0be9b568857c7bec9fda95a89f87b783546d02951c40c33f84d05bb7da3fd10f863a9beb901463669b6583173a8c8cc6d6b306ea2b9b9d5d3d943c3a673
   languageName: node
   linkType: hard
 
@@ -2122,6 +2603,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "ignore@npm:5.3.1"
+  checksum: 71d7bb4c1dbe020f915fd881108cbe85a0db3d636a0ea3ba911393c53946711d13a9b1143c7e70db06d571a5822c0a324a6bcde5c9904e7ca5047f01f1bf8cd3
+  languageName: node
+  linkType: hard
+
+"import-fresh@npm:^3.2.1":
+  version: 3.3.0
+  resolution: "import-fresh@npm:3.3.0"
+  dependencies:
+    parent-module: ^1.0.0
+    resolve-from: ^4.0.0
+  checksum: 2cacfad06e652b1edc50be650f7ec3be08c5e5a6f6d12d035c440a42a8cc028e60a5b99ca08a77ab4d6b1346da7d971915828f33cdab730d3d42f08242d09baa
+  languageName: node
+  linkType: hard
+
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -2311,7 +2809,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.1":
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -2363,6 +2861,13 @@ __metadata:
   dependencies:
     symbol-observable: ^1.1.0
   checksum: ab3d7e740915e6b53a81d96ce7d581f4dd26dacceb95278b74e7bf3123221073ea02cde810f864cff94ed5c394f18248deefd6a8f2d40137d868130eb5be6f85
+  languageName: node
+  linkType: hard
+
+"is-path-inside@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "is-path-inside@npm:3.0.3"
+  checksum: abd50f06186a052b349c15e55b182326f1936c89a78bf6c8f2b707412517c097ce04bc49a0ca221787bc44e1049f51f09a2ffb63d22899051988d3a618ba13e9
   languageName: node
   linkType: hard
 
@@ -2519,6 +3024,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
+  languageName: node
+  linkType: hard
+
+"json-buffer@npm:3.0.1":
+  version: 3.0.1
+  resolution: "json-buffer@npm:3.0.1"
+  checksum: 9026b03edc2847eefa2e37646c579300a1f3a4586cfb62bf857832b60c852042d0d6ae55d1afb8926163fa54c2b01d83ae24705f34990348bdac6273a29d4581
+  languageName: node
+  linkType: hard
+
 "json-parse-better-errors@npm:^1.0.1":
   version: 1.0.2
   resolution: "json-parse-better-errors@npm:1.0.2"
@@ -2530,6 +3053,20 @@ __metadata:
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 798ed4cf3354a2d9ccd78e86d2169515a0097a5c133337807cdf7f1fc32e1391d207ccfc276518cc1d7d8d4db93288b8a50ba4293d212ad1336e52a8ec0a941f
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "json-schema-traverse@npm:0.4.1"
+  checksum: 7486074d3ba247769fda17d5181b345c9fb7d12e0da98b22d1d71a5db9698d8b4bd900a3ec1a4ffdd60846fc2556274a5c894d0c48795f14cb03aeae7b55260b
+  languageName: node
+  linkType: hard
+
+"json-stable-stringify-without-jsonify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
+  checksum: cff44156ddce9c67c44386ad5cddf91925fe06b1d217f2da9c4910d01f358c6e3989c4d5a02683c7a5667f9727ff05831f7aa8ae66c8ff691c556f0884d49215
   languageName: node
   linkType: hard
 
@@ -2558,6 +3095,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"keyv@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "keyv@npm:4.5.4"
+  dependencies:
+    json-buffer: 3.0.1
+  checksum: 74a24395b1c34bd44ad5cb2b49140d087553e170625240b86755a6604cd65aa16efdbdeae5cdb17ba1284a0fbb25ad06263755dbc71b8d8b06f74232ce3cdd72
+  languageName: node
+  linkType: hard
+
 "kind-of@npm:^6.0.3":
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
@@ -2569,6 +3115,16 @@ __metadata:
   version: 4.1.5
   resolution: "kleur@npm:4.1.5"
   checksum: 1dc476e32741acf0b1b5b0627ffd0d722e342c1b0da14de3e8ae97821327ca08f9fb944542fb3c126d90ac5f27f9d804edbe7c585bf7d12ef495d115e0f22c12
+  languageName: node
+  linkType: hard
+
+"levn@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "levn@npm:0.4.1"
+  dependencies:
+    prelude-ls: ^1.2.1
+    type-check: ~0.4.0
+  checksum: 12c5021c859bd0f5248561bf139121f0358285ec545ebf48bb3d346820d5c61a4309535c7f387ed7d84361cf821e124ce346c6b7cef8ee09a67c1473b46d0fc4
   languageName: node
   linkType: hard
 
@@ -2672,6 +3228,13 @@ __metadata:
   dependencies:
     p-locate: ^5.0.0
   checksum: 72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
+"lodash.merge@npm:^4.6.2":
+  version: 4.6.2
+  resolution: "lodash.merge@npm:4.6.2"
+  checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
   languageName: node
   linkType: hard
 
@@ -2872,7 +3435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.1.1":
+"minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -2887,6 +3450,15 @@ __metadata:
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 7564208ef81d7065a370f788d337cd80a689e981042cb9a1d0e6580b6c6a8c9279eba80010516e258835a988363f99f54a6f711a315089b8b42694f5da9d0d77
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "minimatch@npm:9.0.4"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: cf717f597ec3eed7dabc33153482a2e8d49f4fd3c26e58fd9c71a94c5029a0838728841b93f46bf1263b65a8010e2ee800d0dc9b004ab8ba8b6d1ec07cc115b5
   languageName: node
   linkType: hard
 
@@ -3019,6 +3591,13 @@ __metadata:
   version: 1.0.0
   resolution: "mute-stream@npm:1.0.0"
   checksum: 36fc968b0e9c9c63029d4f9dc63911950a3bdf55c9a87f58d3a266289b67180201cade911e7699f8b2fa596b34c9db43dad37649e3f7fdd13c3bb9edb0017ee7
+  languageName: node
+  linkType: hard
+
+"natural-compare@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "natural-compare@npm:1.4.0"
+  checksum: 23ad088b08f898fc9b53011d7bb78ec48e79de7627e01ab5518e806033861bef68d5b0cd0e2205c2f36690ac9571ff6bcb05eb777ced2eeda8d4ac5b44592c3d
   languageName: node
   linkType: hard
 
@@ -3201,6 +3780,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"optionator@npm:^0.9.3":
+  version: 0.9.4
+  resolution: "optionator@npm:0.9.4"
+  dependencies:
+    deep-is: ^0.1.3
+    fast-levenshtein: ^2.0.6
+    levn: ^0.4.1
+    prelude-ls: ^1.2.1
+    type-check: ^0.4.0
+    word-wrap: ^1.2.5
+  checksum: ecbd010e3dc73e05d239976422d9ef54a82a13f37c11ca5911dff41c98a6c7f0f163b27f922c37e7f8340af9d36febd3b6e9cef508f3339d4c393d7276d716bb
+  languageName: node
+  linkType: hard
+
 "ora@npm:^6.1.2":
   version: 6.3.0
   resolution: "ora@npm:6.3.0"
@@ -3304,6 +3897,15 @@ __metadata:
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: f8a8e9a7693659383f06aec604ad5ead237c7a261c18048a6e1b5b85a5f8a067e469aa24f5bc009b991ea3b058a87f5065ef4176793a200d4917349881216cae
+  languageName: node
+  linkType: hard
+
+"parent-module@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "parent-module@npm:1.0.1"
+  dependencies:
+    callsites: ^3.0.0
+  checksum: 6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
   languageName: node
   linkType: hard
 
@@ -3440,6 +4042,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prelude-ls@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "prelude-ls@npm:1.2.1"
+  checksum: cd192ec0d0a8e4c6da3bb80e4f62afe336df3f76271ac6deb0e6a36187133b6073a19e9727a1ff108cd8b9982e4768850d413baa71214dd80c7979617dca827a
+  languageName: node
+  linkType: hard
+
+"prettier-linter-helpers@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "prettier-linter-helpers@npm:1.0.0"
+  dependencies:
+    fast-diff: ^1.1.2
+  checksum: 00ce8011cf6430158d27f9c92cfea0a7699405633f7f1d4a45f07e21bf78e99895911cbcdc3853db3a824201a7c745bd49bfea8abd5fb9883e765a90f74f8392
+  languageName: node
+  linkType: hard
+
 "prettier@npm:3.2.5":
   version: 3.2.5
   resolution: "prettier@npm:3.2.5"
@@ -3489,6 +4107,13 @@ __metadata:
     end-of-stream: ^1.1.0
     once: ^1.3.1
   checksum: e42e9229fba14732593a718b04cb5e1cfef8254544870997e0ecd9732b189a48e1256e4e5478148ecb47c8511dca2b09eae56b4d0aad8009e6fac8072923cfc9
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: bb0a0ceedca4c3c57a9b981b90601579058903c62be23c5e8e843d2c2d4148a3ecf029d5133486fb0e1822b098ba8bba09e89d6b21742d02fa26bda6441a6fb2
   languageName: node
   linkType: hard
 
@@ -3609,6 +4234,13 @@ __metadata:
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
   checksum: e9e294695fea08b076457e9ddff854e81bffbe248ed34c1eec348b7abbd22a0d02e8d75506559e2265e96978f3c4720bd77a6dad84755de8162b357eb6c778c7
+  languageName: node
+  linkType: hard
+
+"resolve-from@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "resolve-from@npm:4.0.0"
+  checksum: f4ba0b8494846a5066328ad33ef8ac173801a51739eb4d63408c847da9a2e1c1de1e6cbbf72699211f3d13f8fc1325648b169bd15eb7da35688e30a5fb0e4a7f
   languageName: node
   linkType: hard
 
@@ -3833,6 +4465,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.6.0":
+  version: 7.6.2
+  resolution: "semver@npm:7.6.2"
+  bin:
+    semver: bin/semver.js
+  checksum: 40f6a95101e8d854357a644da1b8dd9d93ce786d5c6a77227bc69dbb17bea83d0d1d1d7c4cd5920a6df909f48e8bd8a5909869535007f90278289f2451d0292d
   languageName: node
   linkType: hard
 
@@ -4210,6 +4851,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-json-comments@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "strip-json-comments@npm:3.1.1"
+  checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
@@ -4249,6 +4897,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"synckit@npm:^0.8.6":
+  version: 0.8.8
+  resolution: "synckit@npm:0.8.8"
+  dependencies:
+    "@pkgr/core": ^0.1.0
+    tslib: ^2.6.2
+  checksum: 9ed5d33abb785f5f24e2531efd53b2782ca77abf7912f734d170134552b99001915531be5a50297aa45c5701b5c9041e8762e6cd7a38e41e2461c1e7fccdedf8
+  languageName: node
+  linkType: hard
+
 "tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.1.13
   resolution: "tar@npm:6.1.13"
@@ -4267,6 +4925,13 @@ __metadata:
   version: 2.2.1
   resolution: "term-size@npm:2.2.1"
   checksum: 1ed981335483babc1e8206f843e06bd2bf89b85f0bf5a9a9d928033a0fcacdba183c03ba7d91814643015543ba002f1339f7112402a21da8f24b6c56b062a5a9
+  languageName: node
+  linkType: hard
+
+"text-table@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "text-table@npm:0.2.0"
+  checksum: b6937a38c80c7f84d9c11dd75e49d5c44f71d95e810a3250bd1f1797fc7117c57698204adf676b71497acc205d769d65c16ae8fa10afad832ae1322630aef10a
   languageName: node
   linkType: hard
 
@@ -4302,6 +4967,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-api-utils@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "ts-api-utils@npm:1.3.0"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: c746ddabfdffbf16cb0b0db32bb287236a19e583057f8649ee7c49995bb776e1d3ef384685181c11a1a480369e022ca97512cb08c517b2d2bd82c83754c97012
+  languageName: node
+  linkType: hard
+
 "tslib@npm:2.5.0, tslib@npm:^2.1.0":
   version: 2.5.0
   resolution: "tslib@npm:2.5.0"
@@ -4313,6 +4987,13 @@ __metadata:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
   languageName: node
   linkType: hard
 
@@ -4330,6 +5011,15 @@ __metadata:
   bin:
     tty-table: adapters/terminal-adapter.js
   checksum: e058c0bd553c515d2ed908eb5f6a220a412e160168ef5c87847c62dacf78a7de9ccb548d7f6cd5edbcce2301c389ac2858c10aa330dccea2764809beb63d1d7b
+  languageName: node
+  linkType: hard
+
+"type-check@npm:^0.4.0, type-check@npm:~0.4.0":
+  version: 0.4.0
+  resolution: "type-check@npm:0.4.0"
+  dependencies:
+    prelude-ls: ^1.2.1
+  checksum: ec688ebfc9c45d0c30412e41ca9c0cdbd704580eb3a9ccf07b9b576094d7b86a012baebc95681999dd38f4f444afd28504cb3a89f2ef16b31d4ab61a0739025a
   languageName: node
   linkType: hard
 
@@ -4408,6 +5098,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript-eslint@npm:^7.10.0":
+  version: 7.10.0
+  resolution: "typescript-eslint@npm:7.10.0"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": 7.10.0
+    "@typescript-eslint/parser": 7.10.0
+    "@typescript-eslint/utils": 7.10.0
+  peerDependencies:
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: dfb94e89bc4e4117244509e212c719ff880331737ec682b47f63fa595627e695ed3d1d0121ccda70dc84a3bfed599655bf1cf26ada7620b30c970801c4526832
+  languageName: node
+  linkType: hard
+
 "typescript@npm:5.0.4":
   version: 5.0.4
   resolution: "typescript@npm:5.0.4"
@@ -4478,6 +5184,15 @@ __metadata:
   version: 2.0.0
   resolution: "universalify@npm:2.0.0"
   checksum: 2406a4edf4a8830aa6813278bab1f953a8e40f2f63a37873ffa9a3bc8f9745d06cc8e88f3572cb899b7e509013f7f6fcc3e37e8a6d914167a5381d8440518c44
+  languageName: node
+  linkType: hard
+
+"uri-js@npm:^4.2.2":
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
+  dependencies:
+    punycode: ^2.1.0
+  checksum: 7167432de6817fe8e9e0c9684f1d2de2bb688c94388f7569f7dbdb1587c9f4ca2a77962f134ec90be0cc4d004c939ff0d05acc9f34a0db39a3c797dada262633
   languageName: node
   linkType: hard
 
@@ -4578,6 +5293,13 @@ __metadata:
   dependencies:
     string-width: ^1.0.2 || 2 || 3 || 4
   checksum: d5fc37cd561f9daee3c80e03b92ed3e84d80dde3365a8767263d03dacfc8fa06b065ffe1df00d8c2a09f731482fcacae745abfbb478d4af36d0a891fad4834d3
+  languageName: node
+  linkType: hard
+
+"word-wrap@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "word-wrap@npm:1.2.5"
+  checksum: f93ba3586fc181f94afdaff3a6fef27920b4b6d9eaefed0f428f8e07adea2a7f54a5f2830ce59406c8416f033f86902b91eb824072354645eea687dff3691ccb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description : 

- Configured prettier inline with SE-2 repo config
- Formatted files with prettier
- Configured [ESlint v9](https://eslint.org/docs/latest/use/getting-started) and [typescript-eslint](https://typescript-eslint.io/getting-started/)
- Both prettier and eslint ignores templates dir
- Fixed eslint issues
- Configured pre-commit hooks with husky and lint-staged


Tried keeping typescript-eslint rules inline with SE-2. 

## To test : 
1. Install dependencies : 
```
yarn install
```

2. Add `const x = 5` in `src/cli.ts` and try running : 
```
git add . && git commit -m "this should fail"
```

This will run pre-commit and hopefully it should fail (since x is unused variable) 

cc @Pabl0cks, could you please test this on windows also once, because I remmember in SE-2 while configuring husky it was not working properly especially for windows. 

## New Commands : 

To run lint : 

```
yarn lint
```

or to fix all fixable errors:  `yarn lint --fix`

To format files with prettier : 

```
yarn format
```

