### PR TITLE
fix foundry gh-actions

### DIFF
--- a/.changeset/shaggy-eagles-chew.md
+++ b/.changeset/shaggy-eagles-chew.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+fix foundry gh-actions

--- a/templates/base/.github/workflows/lint.yaml.template.mjs
+++ b/templates/base/.github/workflows/lint.yaml.template.mjs
@@ -1,4 +1,7 @@
-name: Lint
+import { withDefaults } from "../../../utils.js";
+
+const contents = ({ solidityEnvSetup }) =>
+  `name: Lint
 
 on:
   push:
@@ -10,7 +13,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ${{ matrix.os }}
+    runs-on: \${{ matrix.os }}
 
     strategy:
       matrix:
@@ -24,20 +27,18 @@ jobs:
       - name: Setup node env
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: \${{ matrix.node }}
           cache: yarn
 
       - name: Install dependencies
         run: yarn install --immutable
-
-      - name: Run hardhat node, deploy contracts (& generate contracts typescript output)
-        run: yarn chain & yarn deploy
-
+      ${solidityEnvSetup.filter(Boolean).join("\n")}
       - name: Run nextjs lint
         run: yarn next:lint --max-warnings=0
 
       - name: Check typings on nextjs
-        run: yarn next:check-types
+        run: yarn next:check-types`;
 
-      - name: Run hardhat lint
-        run: yarn hardhat:lint --max-warnings=0
+export default withDefaults(contents, {
+  solidityEnvSetup: undefined,
+});

--- a/templates/extensions/foundry/.github/workflows/lint.yaml.args.mjs
+++ b/templates/extensions/foundry/.github/workflows/lint.yaml.args.mjs
@@ -1,0 +1,11 @@
+export const solidityEnvSetup = `
+      - name: Install foundry-toolchain
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run foundry node, deploy contracts (& generate contracts typescript output)
+        env:
+          ETHERSCAN_API_KEY: \${{ secrets.ETHERSCAN_API_KEY }}
+        run: yarn chain & yarn deploy
+`;

--- a/templates/extensions/foundry/packages/foundry/.gitignore.template.mjs
+++ b/templates/extensions/foundry/packages/foundry/.gitignore.template.mjs
@@ -1,5 +1,5 @@
-const contents = () => 
-`# Compiler files
+const contents = () =>
+  `# Compiler files
 cache/
 out/
 
@@ -8,12 +8,16 @@ out/
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 
+# Ignore 31337 deployments
+/deployments/31337.json
+
 # Docs
 docs/
 
 # Dotenv file
 .env
 localhost.json
-`
+`;
 
-export default contents
+export default contents;
+

--- a/templates/extensions/foundry/packages/foundry/deployments/.gitignore
+++ b/templates/extensions/foundry/packages/foundry/deployments/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/templates/extensions/hardhat/.github/workflows/lint.yaml.args.mjs
+++ b/templates/extensions/hardhat/.github/workflows/lint.yaml.args.mjs
@@ -1,0 +1,7 @@
+export const solidityEnvSetup = `
+      - name: Run hardhat node, deploy contracts (& generate contracts typescript output)
+        run: yarn chain & yarn deploy
+
+      - name: Run hardhat lint
+        run: yarn hardhat:lint --max-warnings=0
+`;


### PR DESCRIPTION
### Description : 

1. Templatised lint.yaml depending on solidity frameWork option chosen
2. In foundry gitignore only ignore deployments of `31337.json`  and unignore rest all chains. 
    - If we don't do above, when we have deployed contract on other chain (it will be present in broadcast dir) but not in `deployments` dir which causes the action to fail checkout this [example](https://github.com/technophile-04/subgraph-foundry/actions/runs/9240550369/job/25420965111)
    - After unignoring  other chains it started passing checkout example [here](https://github.com/technophile-04/subgraph-foundry/actions/runs/9240733250/job/25421362566)