### PR TITLE
configure lint gh-action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [lts/*]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Setup node env
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run lint
+        run: yarn lint --max-warnings=0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,10 +9,9 @@ export async function cli(args: Args) {
   try {
     renderIntroMessage();
     const rawOptions = await parseArgumentsIntoOptions(args);
-    const options =   await promptForMissingOptions(rawOptions);
+    const options = await promptForMissingOptions(rawOptions);
     await createProject(options);
-  } catch (error: any) 
-{
+  } catch (error: any) {
     console.error(chalk.red.bold(error.message || "An unknown error occurred."));
     return;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,9 +9,10 @@ export async function cli(args: Args) {
   try {
     renderIntroMessage();
     const rawOptions = await parseArgumentsIntoOptions(args);
-    const options = await promptForMissingOptions(rawOptions);
+    const options =   await promptForMissingOptions(rawOptions);
     await createProject(options);
-  } catch (error: any) {
+  } catch (error: any) 
+{
     console.error(chalk.red.bold(error.message || "An unknown error occurred."));
     return;
   }


### PR DESCRIPTION
## Description

Created a lint workflow similar to SE-2 repo which runs wherever a PR is created against main and after merging / pushing things to main. 

Here is failed example, where I commited with `--no-verify` flag an un formatted code https://github.com/scaffold-eth/create-eth/actions/runs/9272915257/job/25511808068

Fixes #22 