### PR TITLE
templatised foundry deploy script

### DIFF
--- a/templates/extensions/foundry/packages/foundry/deployments/31337.json
+++ b/templates/extensions/foundry/packages/foundry/deployments/31337.json
@@ -1,0 +1,3 @@
+{
+  "networkName": "Anvil"
+}

--- a/templates/extensions/foundry/packages/foundry/script/Deploy.s.sol.template.mjs
+++ b/templates/extensions/foundry/packages/foundry/script/Deploy.s.sol.template.mjs
@@ -1,8 +1,11 @@
-//SPDX-License-Identifier: MIT
+import { withDefaults } from "../../../../../utils.js";
+
+const content = ({ deploymentsScriptsImports, deploymentsLogic }) => `//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 import "../contracts/YourContract.sol";
 import "./DeployHelpers.s.sol";
+${deploymentsScriptsImports.filter(Boolean).join("\n")}
 
 contract DeployScript is ScaffoldETHDeploy {
     error InvalidPrivateKey(string);
@@ -11,17 +14,23 @@ contract DeployScript is ScaffoldETHDeploy {
         uint256 deployerPrivateKey = setupLocalhostEnv();
         if (deployerPrivateKey == 0) {
             revert InvalidPrivateKey(
-                "You don't have a deployer account. Make sure you have set DEPLOYER_PRIVATE_KEY in .env or use `yarn generate` to generate a new random account"
+                "You don't have a deployer account. Make sure you have set DEPLOYER_PRIVATE_KEY in .env or use \`yarn generate\` to generate a new random account"
             );
         }
         vm.startBroadcast(deployerPrivateKey);
-        YourContract yourContract =
-            new YourContract(vm.addr(deployerPrivateKey));
+
+        YourContract yourContract = new YourContract(
+            vm.addr(deployerPrivateKey)
+        );
         console.logString(
             string.concat(
-                "YourContract deployed at: ", vm.toString(address(yourContract))
+                "YourContract deployed at: ",
+                vm.toString(address(yourContract))
             )
         );
+
+        ${deploymentsLogic.filter(Boolean).join("\n")}
+
         vm.stopBroadcast();
 
         /**
@@ -33,4 +42,9 @@ contract DeployScript is ScaffoldETHDeploy {
     }
 
     function test() public {}
-}
+}`;
+
+export default withDefaults(content, {
+  deploymentsScriptsImports: "",
+  deploymentsLogic: "",
+});

--- a/templates/extensions/foundry/packages/foundry/script/Deploy.s.sol.template.mjs
+++ b/templates/extensions/foundry/packages/foundry/script/Deploy.s.sol.template.mjs
@@ -29,9 +29,9 @@ contract DeployScript is ScaffoldETHDeploy {
             )
         );
 
-        ${deploymentsLogic.filter(Boolean).join("\n")}
-
         vm.stopBroadcast();
+
+        ${deploymentsLogic.filter(Boolean).join("\n")}
 
         /**
          * This function generates the file containing the contracts Abi definitions.


### PR DESCRIPTION
### Description : 

This will allow people to create extension's which adds new contract and also deployments for them. 

### To test : 
Switch to this branch then: 

1. Start cli : 
```
yarn dev
```
2. Scaffold new app, with eip-5792 extension: 

```
yarn cli -e technophile-04/eip-5792:foundry
```

3. Choose foundry as extension too

Here is extension [repo](https://github.com/technophile-04/eip-5792/tree/foundry/extension/packages)

--- 

Adding contracts and deployments in hardhat does not require any templatisation since we can create separate `01_deploy_..` file and main deploy script `99_deploy...` will consider all the deployments. 

But in foundry this is not the case [checkout this](https://github.com/scaffold-eth/scaffold-eth-2/pull/781#issuecomment-2018642266) for more details

