### PR TITLE
remove console log from runPrettier function

### DIFF
--- a/src/tasks/prettier-format.ts
+++ b/src/tasks/prettier-format.ts
@@ -4,7 +4,6 @@ import { Options } from "../types";
 import { SOLIDITY_FRAMEWORKS } from "../utils/consts";
 
 async function runPrettier(targetPath: string[], prettierConfigPath: string, prettierPlugins: string[]) {
-  console.log("the prettier config path is", prettierConfigPath);
   const result = await execa("yarn", [
     "prettier",
     "--write",


### PR DESCRIPTION
### Description: 

Noticed this while testing #68, actually I we forgot to remove extra console.log in #55 
![image](https://github.com/scaffold-eth/create-eth/assets/80153681/764ed2a7-8f85-42ff-8aae-e9f28fbe0843)
