### PR TITLE
patch: prettier formatting error

### DIFF
--- a/.changeset/cool-pandas-kiss.md
+++ b/.changeset/cool-pandas-kiss.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+cli: prettier formatting error

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,15 +36,21 @@ export async function createProject(options: Options) {
         task: () => copyTemplateFiles(options, templateDirectory, targetDirectory),
       },
       {
-        title: "🪄 Formatting files",
-        task: () => prettierFormat(targetDirectory, options),
-      },
-      {
         title: `📦 Installing dependencies with yarn, this could take a while`,
         task: () => installPackages(targetDirectory),
         skip: () => {
           if (!options.install) {
             return "Manually skipped";
+          }
+          return false;
+        },
+      },
+      {
+        title: "🪄 Formatting files",
+        task: () => prettierFormat(targetDirectory),
+        skip: () => {
+          if (!options.install) {
+            return "`yarn install` was skipped";
           }
           return false;
         },

--- a/src/tasks/prettier-format.ts
+++ b/src/tasks/prettier-format.ts
@@ -1,53 +1,15 @@
 import { execa } from "execa";
-import path from "path";
-import { Options } from "../types";
-import { SOLIDITY_FRAMEWORKS } from "../utils/consts";
 
-async function runPrettier(targetPath: string[], prettierConfigPath: string, prettierPlugins: string[]) {
-  const result = await execa("yarn", [
-    "prettier",
-    "--write",
-    ...targetPath,
-    "--config",
-    prettierConfigPath,
-    ...prettierPlugins,
-    "--no-editorconfig",
-  ]);
-  if (result.failed) {
-    throw new Error(`There was a problem running prettier in ${targetPath.join(" ")}`);
-  }
-}
-
-export async function prettierFormat(targetDir: string, options: Options) {
+// TODO: Instead of using execa, use prettier package from cli to format targetDir
+export async function prettierFormat(targetDir: string) {
   try {
-    const nextJsPath = path.join(targetDir, "packages", "nextjs");
-    const nextPrettierConfig = path.join(nextJsPath, ".prettierrc.json");
+    const result = await execa("yarn", ["format"], { cwd: targetDir });
 
-    await runPrettier([nextJsPath], nextPrettierConfig, ["--plugin=@trivago/prettier-plugin-sort-imports"]);
-
-    if (options.solidityFramework === SOLIDITY_FRAMEWORKS.HARDHAT) {
-      const hardhatPackagePath = path.join(targetDir, "packages", SOLIDITY_FRAMEWORKS.HARDHAT);
-      const hardhatPrettierConfig = path.join(hardhatPackagePath, ".prettierrc.json");
-      const hardhatPaths = [
-        `${hardhatPackagePath}/*.ts`,
-        `${hardhatPackagePath}/deploy/**/*.ts`,
-        `${hardhatPackagePath}/scripts/**/*.ts`,
-        `${hardhatPackagePath}/test/**/*.ts`,
-        `${hardhatPackagePath}/contracts/**/*.sol`,
-      ];
-
-      await runPrettier(hardhatPaths, hardhatPrettierConfig, ["--plugin=prettier-plugin-solidity"]);
-    }
-
-    if (options.solidityFramework === SOLIDITY_FRAMEWORKS.FOUNDRY) {
-      const foundryPackagePath = path.resolve(targetDir, "packages", SOLIDITY_FRAMEWORKS.FOUNDRY);
-      const foundryResult = await execa("forge", ["fmt"], { cwd: foundryPackagePath });
-      if (foundryResult.failed) {
-        throw new Error("There was a problem running forge fmt in the foundry package");
-      }
+    if (result.failed) {
+      throw new Error("There was a problem running the format command");
     }
   } catch (error) {
-    throw new Error("Failed to run prettier", { cause: error });
+    throw new Error("Failed to create directory", { cause: error });
   }
 
   return true;

--- a/src/utils/render-outro-message.ts
+++ b/src/utils/render-outro-message.ts
@@ -12,6 +12,13 @@ export function renderOutroMessage(options: Options) {
   ${chalk.dim("cd")} ${options.project}
   `;
 
+  if (!options.install) {
+    message += `
+    \t${chalk.bold("Install dependencies & format files")}
+    \t${chalk.dim("yarn")} install && ${chalk.dim("yarn")} format
+    `;
+  }
+
   if (
     options.solidityFramework === SOLIDITY_FRAMEWORKS.HARDHAT ||
     options.solidityFramework === SOLIDITY_FRAMEWORKS.FOUNDRY


### PR DESCRIPTION
### Description: 

If you run `npx create-eth@latest` we get this error: 

<details>

<summary>
Error : 
</summary>

![image](https://github.com/scaffold-eth/create-eth/assets/80153681/f216d044-ead6-4b74-8800-e20664610ec6)


</details>

The problem seems to occur because the directory in which we run `npx create-eth@latest` seems to be used as current directory while running `yarn prettier ...` command and since no `package.json` / `prettier` is present in that directory (where users calls `npx create-eth@latest`) it fails. 

I think it worked for us in testing #29 and #55 because we were calling `yarn cli ${instanceName}` and since `yarn cli` dir was `create-eth` it worked. 

### Solution for now as patch: 

Run prettier after dependencies are installed (same as perviously we were doing)

If `install` is skipped we log this : 

<details>

<summary>
Example : 
</summary>

![Screenshot 2024-07-09 at 4 57 46 PM](https://github.com/scaffold-eth/create-eth/assets/80153681/ea15a7c6-d4e4-41d4-8d97-29404b11c694)


</details>

If it was not skipped we format and don't log any skipped info: 

<details>

<summary>
Example : 
</summary>



</details>