### PR TITLE
feat: update merge packages info

### DIFF
--- a/contributors/TEMPLATING.md
+++ b/contributors/TEMPLATING.md
@@ -176,7 +176,7 @@ The special files and folders are:
 
 ## Merging package.json files
 
-The package we use to merge `package.json` files [merge-packages](3) will attempt to find intersections of dependencies or use the latest version of a dependency in case of a conflict.
+The package we use to merge `package.json` files [merge-packages](3) will attempt to find intersections of dependencies. If there is a conflict, the version from the last `package.json` will be taken.
 
 For example:
 

--- a/contributors/TEMPLATING.md
+++ b/contributors/TEMPLATING.md
@@ -176,9 +176,19 @@ The special files and folders are:
 
 ## Merging package.json files
 
-The package we use to merge package.json files [merge-packages](3) will use the last version of a dependency given a conflict. For example:
+The package we use to merge `package.json` files [merge-packages](3) will attempt to find intersections of dependencies or use the latest version of a dependency in case of a conflict.
+
+For example:
 
 ```
+version on file one: ~1.2.3
+version on file two: ^1.0.0
+resulting version: ~1.2.3
+
+version on file one: ^1.0.0
+version on file two: >=1.2.0 <1.3.0
+resulting version: ~1.2.0
+
 version on file one: 1.0.0
 version on file two: 0.1.0
 resulting version: 0.1.0


### PR DESCRIPTION
For me it wasn't clear how versions in merged `package.json` files are defined. From readme, I thought that always version from second `package.json` is taken. So I updated readme to make it clear for other devs. 

Source https://github.com/zppack/merge-packages/blob/master/src/index.js#L104

If you want to test examples, you can add this to your first `templates/base/packages/nextjs/package.json` deps

```
    "a": "~1.2.3",
    "b": "^1.0.0",
```
and create new `package.json` at `templates/solidity-frameworks/hardhat/packages/nextjs/package.json
```
{
  "dependencies": {
    "a": "^1.0.0",
    "b": ">=1.2.0 <1.3.0"
  }
}
```
run 
```
yarn cli -s hardhat --skip test-packages-merge
```
and check resulting nextjs package


