### PR TITLE
fix: soidity frameworks folders

### DIFF
--- a/.changeset/spotty-rocks-notice.md
+++ b/.changeset/spotty-rocks-notice.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+fix: copy only chosen solidity framework folder

--- a/src/tasks/copy-template-files.ts
+++ b/src/tasks/copy-template-files.ts
@@ -9,7 +9,7 @@ import path from "path";
 import { promisify } from "util";
 import link from "../utils/link";
 import { getArgumentFromExternalExtensionOption } from "../utils/external-extensions";
-import { BASE_DIR, SOLIDITY_FRAMEWORKS_DIR } from "../utils/consts";
+import { BASE_DIR, SOLIDITY_FRAMEWORKS, SOLIDITY_FRAMEWORKS_DIR } from "../utils/consts";
 
 const EXTERNAL_EXTENSION_TMP_DIR = "tmp-external-extension";
 
@@ -65,7 +65,11 @@ const copyBaseFiles = async (basePath: string, targetDir: string, { dev: isDev }
   }
 };
 
-const copyExtensionsFiles = async ({ dev: isDev }: Options, extensionPath: string, targetDir: string) => {
+const copyExtensionFiles = async (
+  { dev: isDev, solidityFramework }: Options,
+  extensionPath: string,
+  targetDir: string,
+) => {
   // copy (or link if dev) root files
   await copyOrLink(extensionPath, path.join(targetDir), {
     clobber: false,
@@ -96,7 +100,14 @@ const copyExtensionsFiles = async ({ dev: isDev }: Options, extensionPath: strin
         const isArgs = isArgsRegex.test(path);
         const isTemplate = isTemplateRegex.test(path);
         const isPackageJson = isPackageJsonRegex.test(path);
-        const shouldSkip = isArgs || isTemplate || isPackageJson;
+
+        const unselectedSolidityFrameworks = [SOLIDITY_FRAMEWORKS.FOUNDRY, SOLIDITY_FRAMEWORKS.HARDHAT].filter(
+          sf => sf !== solidityFramework,
+        );
+        const isUselectedSolidityFrameworksRegexes = unselectedSolidityFrameworks.map(sf => new RegExp(`${sf}$`));
+        const isUnselectedSolidityFramework = isUselectedSolidityFrameworksRegexes.some(sfregex => sfregex.test(path));
+
+        const shouldSkip = isArgs || isTemplate || isPackageJson || isUnselectedSolidityFramework;
 
         return !shouldSkip;
       },
@@ -293,7 +304,7 @@ export async function copyTemplateFiles(options: Options, templateDir: string, t
     options.solidityFramework && getSolidityFrameworkPath(options.solidityFramework, templateDir);
 
   if (solidityFrameworkPath) {
-    await copyExtensionsFiles(options, solidityFrameworkPath, targetDir);
+    await copyExtensionFiles(options, solidityFrameworkPath, targetDir);
   }
 
   // 3. Set up external extension if needed
@@ -310,7 +321,7 @@ export async function copyTemplateFiles(options: Options, templateDir: string, t
       await setUpExternalExtensionFiles(options, tmpDir);
     }
 
-    await copyExtensionsFiles(options, externalExtensionPath, targetDir);
+    await copyExtensionFiles(options, externalExtensionPath, targetDir);
   }
 
   // 4. Process templated files and generate output

--- a/src/tasks/copy-template-files.ts
+++ b/src/tasks/copy-template-files.ts
@@ -104,8 +104,8 @@ const copyExtensionFiles = async (
         const unselectedSolidityFrameworks = [SOLIDITY_FRAMEWORKS.FOUNDRY, SOLIDITY_FRAMEWORKS.HARDHAT].filter(
           sf => sf !== solidityFramework,
         );
-        const isUselectedSolidityFrameworksRegexes = unselectedSolidityFrameworks.map(sf => new RegExp(`${sf}$`));
-        const isUnselectedSolidityFramework = isUselectedSolidityFrameworksRegexes.some(sfregex => sfregex.test(path));
+        const isUnselectedSolidityFrameworksRegexes = unselectedSolidityFrameworks.map(sf => new RegExp(`${sf}$`));
+        const isUnselectedSolidityFramework = isUnselectedSolidityFrameworksRegexes.some(sfregex => sfregex.test(path));
 
         const shouldSkip = isArgs || isTemplate || isPackageJson || isUnselectedSolidityFramework;
 

--- a/src/utils/parse-arguments-into-options.ts
+++ b/src/utils/parse-arguments-into-options.ts
@@ -24,7 +24,7 @@ const validateExternalExtension = async (
       );
       await fs.promises.access(`${externalExtensionsDirectory}/${extensionName}`);
     } catch {
-      throw new Error(`Extesnion not found in "externalExtensions/${extensionName}"`);
+      throw new Error(`Extension not found in "externalExtensions/${extensionName}"`);
     }
 
     return extensionName;


### PR DESCRIPTION
Sorry @carletex I didn't notice you self-assigned the issue. 😨 

`-> Only foundry or hardhat folders should be copied / merged if selected.` - this is fixed

Regarding
`-> Ideally "none" option should not be present (or disabled). Maybe a config file in the 3rd party extension?`

Since we show prompts before reading extension, it will require to change flow.

I think we have two simpler options
1. In README of extension add explicit flag `--solidity-framework` and show both options (for me this option is better)

---
```
npx create-eth@latest -e erc-20 --solidity-framework hardhat
```
OR
```
npx create-eth@latest -e erc-20 --solidity-framework foundry
```
---

2. Add flag meaning that solidity framework is required, so options will be without "none"
```
npx create-eth@latest -e erc-20 --required-solidity-framework
```

Fixes https://github.com/scaffold-eth/create-eth/issues/89