### PR TITLE
display solidity framework options based on extension

### DIFF
--- a/.changeset/great-weeks-enjoy.md
+++ b/.changeset/great-weeks-enjoy.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+dispaly correct solidity framework options base on extension

--- a/.changeset/great-weeks-enjoy.md
+++ b/.changeset/great-weeks-enjoy.md
@@ -2,4 +2,4 @@
 "create-eth": patch
 ---
 
-dispaly correct solidity framework options base on extension
+display correct solidity framework options based on extension

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,13 +11,13 @@ import { showHelpMessage } from "./utils/show-help-message";
 export async function cli(args: Args) {
   try {
     renderIntroMessage();
-    const rawOptions = await parseArgumentsIntoOptions(args);
+    const { rawOptions, solidityFrameworkChoices } = await parseArgumentsIntoOptions(args);
     if (rawOptions.help) {
       showHelpMessage();
       return;
     }
 
-    const options = await promptForMissingOptions(rawOptions);
+    const options = await promptForMissingOptions(rawOptions, solidityFrameworkChoices);
     if (options.solidityFramework === SOLIDITY_FRAMEWORKS.FOUNDRY) {
       await validateFoundryUp();
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,3 +32,5 @@ export type TemplateDescriptor = {
   relativePath: string;
   source: string;
 };
+
+export type SolidityFrameworkChoices = (SolidityFramework | { value: any; name: string })[];

--- a/src/utils/external-extensions.ts
+++ b/src/utils/external-extensions.ts
@@ -54,7 +54,7 @@ export const getSolidityFrameworkDirsFromExternalExtension = async (
 ) => {
   const solidityFrameworks = Object.values(SOLIDITY_FRAMEWORKS);
   const filterSolidityFrameworkDirs = (dirs: string[]) => {
-    return dirs.filter(dir => solidityFrameworks.includes(dir as SolidityFramework)) as SolidityFramework[];
+    return dirs.filter(dir => solidityFrameworks.includes(dir as SolidityFramework)).reverse() as SolidityFramework[];
   };
 
   if (typeof externalExtension === "string") {

--- a/src/utils/external-extensions.ts
+++ b/src/utils/external-extensions.ts
@@ -64,11 +64,11 @@ export const getSolidityFrameworkDirsFromExternalExtension = async ({
   }
   const listOfContents = (await res.json()) as { name: string; type: "dir" | "file" }[];
   const directories = listOfContents.filter(item => item.type === "dir").map(dir => dir.name);
-  // filter out the directories which are not solidity frameworks
+
   const soliidtyFrameworks = Object.values(SOLIDITY_FRAMEWORKS);
   const filteredSolidityFrameworkdDirs = directories.filter(dir =>
     soliidtyFrameworks.includes(dir as SolidityFramework),
   );
 
-  return filteredSolidityFrameworkdDirs;
+  return filteredSolidityFrameworkdDirs as SolidityFramework[];
 };

--- a/src/utils/parse-arguments-into-options.ts
+++ b/src/utils/parse-arguments-into-options.ts
@@ -105,11 +105,8 @@ export async function parseArgumentsIntoOptions(
     { value: null, name: "none" },
   ];
 
-  if (extension && typeof extension !== "string") {
-    const externalExtensionSolidityFrameworkDirs = await getSolidityFrameworkDirsFromExternalExtension({
-      repositoryURL: extension.repository,
-      branch: extension.branch,
-    });
+  if (extension) {
+    const externalExtensionSolidityFrameworkDirs = await getSolidityFrameworkDirsFromExternalExtension(extension);
 
     if (externalExtensionSolidityFrameworkDirs.length !== 0) {
       solidityFrameworkChoices = externalExtensionSolidityFrameworkDirs;

--- a/src/utils/parse-arguments-into-options.ts
+++ b/src/utils/parse-arguments-into-options.ts
@@ -1,4 +1,4 @@
-import type { Args, ExternalExtension, SolidityFramework, RawOptions } from "../types";
+import type { Args, ExternalExtension, SolidityFramework, RawOptions, SolidityFrameworkChoices } from "../types";
 import arg from "arg";
 import * as https from "https";
 import {
@@ -54,10 +54,9 @@ const validateExternalExtension = async (
 };
 
 // TODO update smartContractFramework code with general extensions
-// TODO: remove any[] from solidityframeworkchoices
 export async function parseArgumentsIntoOptions(
   rawArgs: Args,
-): Promise<{ rawOptions: RawOptions; solidityFrameworkChoices: any[] }> {
+): Promise<{ rawOptions: RawOptions; solidityFrameworkChoices: SolidityFrameworkChoices }> {
   const args = arg(
     {
       "--skip-install": Boolean,
@@ -104,7 +103,7 @@ export async function parseArgumentsIntoOptions(
     SOLIDITY_FRAMEWORKS.HARDHAT,
     SOLIDITY_FRAMEWORKS.FOUNDRY,
     { value: null, name: "none" },
-  ] as any[];
+  ];
 
   if (extension && typeof extension !== "string") {
     const externalExtensionSolidityFrameworkDirs = await getSolidityFrameworkDirsFromExternalExtension({
@@ -132,7 +131,7 @@ export async function parseArgumentsIntoOptions(
       dev,
       externalExtension: extension,
       help,
-      solidityFramework,
+      solidityFramework: solidityFramework as RawOptions["solidityFramework"],
     },
     solidityFrameworkChoices,
   };

--- a/src/utils/prompt-for-missing-options.ts
+++ b/src/utils/prompt-for-missing-options.ts
@@ -12,12 +12,7 @@ const defaultOptions: RawOptions = {
   help: false,
 };
 
-const nullExtensionChoice = {
-  name: "none",
-  value: null,
-};
-
-export async function promptForMissingOptions(options: RawOptions): Promise<Options> {
+export async function promptForMissingOptions(options: RawOptions, solidityFrameworkChoices: any[]): Promise<Options> {
   const cliAnswers = Object.fromEntries(Object.entries(options).filter(([, value]) => value !== null));
   const questions = [
     {
@@ -31,7 +26,7 @@ export async function promptForMissingOptions(options: RawOptions): Promise<Opti
       type: "list",
       name: "solidityFramework",
       message: "What solidity framework do you want to use?",
-      choices: [SOLIDITY_FRAMEWORKS.HARDHAT, SOLIDITY_FRAMEWORKS.FOUNDRY, nullExtensionChoice],
+      choices: solidityFrameworkChoices,
       default: SOLIDITY_FRAMEWORKS.HARDHAT,
     },
   ];

--- a/src/utils/prompt-for-missing-options.ts
+++ b/src/utils/prompt-for-missing-options.ts
@@ -1,4 +1,4 @@
-import { Options, RawOptions } from "../types";
+import { Options, RawOptions, SolidityFrameworkChoices } from "../types";
 import inquirer from "inquirer";
 import { SOLIDITY_FRAMEWORKS } from "./consts";
 
@@ -12,7 +12,10 @@ const defaultOptions: RawOptions = {
   help: false,
 };
 
-export async function promptForMissingOptions(options: RawOptions, solidityFrameworkChoices: any[]): Promise<Options> {
+export async function promptForMissingOptions(
+  options: RawOptions,
+  solidityFrameworkChoices: SolidityFrameworkChoices,
+): Promise<Options> {
   const cliAnswers = Object.fromEntries(Object.entries(options).filter(([, value]) => value !== null));
   const questions = [
     {


### PR DESCRIPTION
### Description

There are major 3 scenarios: 

1. The external extension don't have any solidity  framework dir 
    Example: 
    ```shell
    yarn cli ../test-eip -e eip-712
    ```
    In this case we show all three options to user on TUI (hardhat, foundry, none)
    
2. The external extension contains only one solidity framework. 
     Example: 
     ```shell
     yarn cli ../test-eip -e technophile-04/eip-5792
     ```
     The [above extension](https://github.com/technophile-04/eip-5792/tree/main/extension/packages) only has `hardhat` so we don't give user any option on TUI and select for them. 
     
     Here there is small catch, what if in above extension user forcefully mention `foundry` using `-s` flag? 
     In this PR, preference is given to external extension directory and `-s` flag is ignored
     
3. The external extension contains both solidity framework 
     Example: 
     ```shell
     yarn cli ../test-erc -e erc-20
     ```
     In this case we show both options without the none option. Fixes #93 