### PR TITLE
Abstraction to several template files for more versatile extensions

### DIFF
--- a/templates/base/packages/nextjs/app/page.tsx
+++ b/templates/base/packages/nextjs/app/page.tsx
@@ -17,10 +17,6 @@ const Home: NextPage = () => {
             <span className="block text-2xl mb-2">Welcome to</span>
             <span className="block text-4xl font-bold">Scaffold-ETH 2</span>
           </h1>
-          <div className="flex justify-center items-center space-x-2 flex-col sm:flex-row">
-            <p className="my-2 font-medium">Connected Address:</p>
-            <Address address={connectedAddress} />
-          </div>
           <p className="text-center text-lg">
             Get started by editing{" "}
             <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">

--- a/templates/base/packages/nextjs/components/Header.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/Header.tsx.template.mjs
@@ -1,5 +1,5 @@
 import { withDefaults } from "../../../../utils.js";
-const contents = ({ menuIconImports, menuObjects }) => {
+const contents = ({ menuIconImports, menuObjects, connectButton}) => {
   return `"use client";
 
 import React, { useCallback, useRef, useState } from "react";
@@ -106,7 +106,7 @@ export const Header = () => {
         </ul>
       </div>
       <div className="navbar-end flex-grow mr-4">
-        <RainbowKitCustomConnectButton />
+        ${connectButton}
         <FaucetButton />
       </div>
     </div>
@@ -117,4 +117,5 @@ export const Header = () => {
 export default withDefaults(contents, {
   menuIconImports: "",
   menuObjects: "",
+  connectButton: "<RainbowKitCustomConnectButton />"
 });

--- a/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
@@ -1,6 +1,6 @@
 import { withDefaults } from "../../../../utils.js";
 
-const contents = ({ providerNames, providerSetups, providerImports, providerProps }) => {
+const contents = ({ providerNames, providerSetups, providerImports, providerProps, walletProviderOpeningTags , walletProviderClosingTags, preSetup, wagmiConfig}) => {
   // filter out empty strings
   const providerOpeningTags = providerNames.filter(Boolean).map((name, index) => `<${name} ${providerProps[index]}>`);
 
@@ -21,6 +21,8 @@ import { ProgressBar } from "~~/components/scaffold-eth/ProgressBar";
 import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 ${providerImports.filter(Boolean).join("\n")}
+
+${preSetup}
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   useInitializeNativeCurrencyPrice();
@@ -57,17 +59,14 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
   }, []);
 
   return (
-    <WagmiProvider config={wagmiConfig}>
+    <WagmiProvider config={${wagmiConfig}}>
       <QueryClientProvider client={queryClient}>
         <ProgressBar />
-        <RainbowKitProvider
-          avatar={BlockieAvatar}
-          theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
-        >
+        ${walletProviderOpeningTags}
           ${providerOpeningTags.join("\n")}
           <ScaffoldEthApp>{children}</ScaffoldEthApp>
           ${providerClosingTags.join("\n")}
-        </RainbowKitProvider>
+        ${walletProviderClosingTags}
       </QueryClientProvider>
     </WagmiProvider>
   );
@@ -79,4 +78,8 @@ export default withDefaults(contents, {
   providerSetups: "",
   providerImports: "",
   providerProps: "",
+  walletProviderOpeningTags: "<RainbowKitProvider avatar={BlockieAvatar} theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}>",
+  walletProviderClosingTags: "</RainbowKitProvider>",
+  preSetup: "",
+  wagmiConfig: "wagmiConfig"
 });

--- a/templates/solidity-frameworks/foundry/packages/nextjs/scaffold.config.ts.args.mjs
+++ b/templates/solidity-frameworks/foundry/packages/nextjs/scaffold.config.ts.args.mjs
@@ -1,1 +1,1 @@
-export const chainName = 'foundry'
+//export const chainName = 'foundry'

--- a/templates/solidity-frameworks/hardhat/packages/nextjs/scaffold.config.ts.args.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/nextjs/scaffold.config.ts.args.mjs
@@ -1,1 +1,1 @@
-export const chainName = 'hardhat'
+//export const chainName = 'hardhat'


### PR DESCRIPTION
Well, I guess I'm back to being disruptive.

This PR is meant to be disruptive and hopefully to make us question and ponder some design choices. Maybe leading to some things being changed, maybe not.

I will try my best to explain the rationale behind the proposed changes. I know that IF the PR were to even be considered for merge, then some additional work needs to be done.

And who knows, maybe it does interfere (I can fully see why) too much with maintaining this codebase alongside the main repository. Thus, a fork of the main repository might've been the best option here.

The completed extension that was built alongside these changes can be found here: https://github.com/hotmanics/walletconnect-extension

# Summary
This PR abstracts several template files to allow for more customization. Specifically, these abstractions were made so that one can replace RainbowKit with Web3Modal or any other Web3 Wallet package if they desire. This can really open the door for true extensibility for many possible implementations provided directly by SE-2.

# File Breakdown
**templates/base/packages/nextjs/app/page.tsx**
Specifically with WalletConnect, I get some Hydration errors using the `Address` component. My guess is that is has something to do with the caching within wagmi. Simply removing it removes this issue. Obviously not an elegant or desired solution, but it does allow for the functionality of RainbowKit and WalletConnect.

### **templates/base/packages/nextjs/components/Header.tsx.template.mjs**
This is modified to take in a new parameter `connectButton` in the `contents` variable. With the default value being the `><RainbowKitCustomConnectButton />` element.

### **templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs**
This is modified to take in the new parameters `walletProviderOpeningTags` , `walletProviderClosingTags`, `preSetup`, `wagmiConfig` in the `contents` variable.

`walletProviderOpeningTags` and `walletProviderClosingTags` are defaulted to the `RainbowKitProvider` elements. However, specifically in the case of WalletConnect, you don't need any extra provider tags. Thus, you can safely provide empty values for those tags. As can be found here: https://github.com/Hotmanics/walletconnect-extension/blob/main/extension/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.args.mjs.

`preSetup` is required, as at the top of the page, WalletConnect requires you to call a synchronously function for initialization. Other synchronous functionality can be placed here.

`wagmiConfig` provides the extension developer the ability to use a custom wagmiConfig. In WalletConnect's case, there needed to be a few extra variables added. The config in the completed extension can be found here: https://github.com/Hotmanics/walletconnect-extension/blob/main/extension/packages/nextjs/services/web3/walletConnectWagmiConfig.tsx

### **templates/solidity-frameworks/foundry/packages/nextjs/scaffold.config.ts.args.mjs**

and 

### **templates/solidity-frameworks/foundry/packages/nextjs/scaffold.config.ts.args.mjs**

Currently, under the assumption of using WalletConnect, when using its email/social login features it does not support foundry or hardhat chains. I don't think they even supports Testnets yet. Thus, SE-2 errors out. Removing those chains entirely, and in the extension forcing, for instance Base, resolves that issue. Maybe foundry can be added as an overridable default?