### PR TITLE
cli: templatise tailwind and hardhat config

### DIFF
--- a/.changeset/odd-bananas-know.md
+++ b/.changeset/odd-bananas-know.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+cli: templatise tailwind and hardhat config

--- a/templates/base/packages/nextjs/tailwind.config.js.template.mjs
+++ b/templates/base/packages/nextjs/tailwind.config.js.template.mjs
@@ -1,4 +1,6 @@
-/** @type {import('tailwindcss').Config} */
+import { withDefaults } from "../../../utils.js";
+
+const contents = ({ lightTheme, darkTheme }) => `/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}", "./utils/**/*.{js,ts,jsx,tsx}"],
   plugins: [require("daisyui")],
@@ -8,7 +10,27 @@ module.exports = {
   daisyui: {
     themes: [
       {
-        light: {
+        light: ${lightTheme},
+      },
+      {
+        dark: ${darkTheme},
+      },
+    ],
+  },
+  theme: {
+    extend: {
+      boxShadow: {
+        center: "0 0 12px -2px rgb(0 0 0 / 0.05)",
+      },
+      animation: {
+        "pulse-fast": "pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite",
+      },
+    },
+  },
+};`;
+
+export default withDefaults(contents, {
+  lightTheme: `{
           primary: "#93BBFB",
           "primary-content": "#212638",
           secondary: "#DAE8FF",
@@ -37,10 +59,8 @@ module.exports = {
           ".link:hover": {
             opacity: "80%",
           },
-        },
-      },
-      {
-        dark: {
+        }`,
+  darkTheme: `{
           primary: "#212638",
           "primary-content": "#F9FBFF",
           secondary: "#323f61",
@@ -70,18 +90,5 @@ module.exports = {
           ".link:hover": {
             opacity: "80%",
           },
-        },
-      },
-    ],
-  },
-  theme: {
-    extend: {
-      boxShadow: {
-        center: "0 0 12px -2px rgb(0 0 0 / 0.05)",
-      },
-      animation: {
-        "pulse-fast": "pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite",
-      },
-    },
-  },
-};
+        }`,
+});

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -140,5 +140,5 @@ const config: HardhatUserConfig = {
 export default config;`;
 
 export default withDefaults(contents, {
-  otherImports: "",
+  imports: "",
 });

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -1,6 +1,6 @@
 import { withDefaults } from "../../../../utils.js";
 
-const contents = ({ otherImports }) => `import * as dotenv from "dotenv";
+const contents = ({ imports }) => `import * as dotenv from "dotenv";
 dotenv.config();
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-ethers";
@@ -11,7 +11,7 @@ import "solidity-coverage";
 import "@nomicfoundation/hardhat-verify";
 import "hardhat-deploy";
 import "hardhat-deploy-ethers";
-${otherImports.filter(Boolean).join("\n")}
+${imports.filter(Boolean).join("\n")}
 
 // If not set, it uses ours Alchemy's default API key.
 // You can get your own at https://dashboard.alchemyapi.io

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -1,4 +1,6 @@
-import * as dotenv from "dotenv";
+import { withDefaults } from "../../../../utils.js";
+
+const contents = ({ otherImports }) => `import * as dotenv from "dotenv";
 dotenv.config();
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-ethers";
@@ -9,6 +11,7 @@ import "solidity-coverage";
 import "@nomicfoundation/hardhat-verify";
 import "hardhat-deploy";
 import "hardhat-deploy-ethers";
+${otherImports.filter(Boolean).join("\n")}
 
 // If not set, it uses ours Alchemy's default API key.
 // You can get your own at https://dashboard.alchemyapi.io
@@ -42,48 +45,48 @@ const config: HardhatUserConfig = {
     // If the network you are looking for is not here you can add new network settings
     hardhat: {
       forking: {
-        url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,
+        url: \`https://eth-mainnet.alchemyapi.io/v2/\${providerApiKey}\`,
         enabled: process.env.MAINNET_FORKING_ENABLED === "true",
       },
     },
     mainnet: {
-      url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,
+      url: \`https://eth-mainnet.alchemyapi.io/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     sepolia: {
-      url: `https://eth-sepolia.g.alchemy.com/v2/${providerApiKey}`,
+      url: \`https://eth-sepolia.g.alchemy.com/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     arbitrum: {
-      url: `https://arb-mainnet.g.alchemy.com/v2/${providerApiKey}`,
+      url: \`https://arb-mainnet.g.alchemy.com/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     arbitrumSepolia: {
-      url: `https://arb-sepolia.g.alchemy.com/v2/${providerApiKey}`,
+      url: \`https://arb-sepolia.g.alchemy.com/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     optimism: {
-      url: `https://opt-mainnet.g.alchemy.com/v2/${providerApiKey}`,
+      url: \`https://opt-mainnet.g.alchemy.com/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     optimismSepolia: {
-      url: `https://opt-sepolia.g.alchemy.com/v2/${providerApiKey}`,
+      url: \`https://opt-sepolia.g.alchemy.com/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     polygon: {
-      url: `https://polygon-mainnet.g.alchemy.com/v2/${providerApiKey}`,
+      url: \`https://polygon-mainnet.g.alchemy.com/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     polygonMumbai: {
-      url: `https://polygon-mumbai.g.alchemy.com/v2/${providerApiKey}`,
+      url: \`https://polygon-mumbai.g.alchemy.com/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     polygonZkEvm: {
-      url: `https://polygonzkevm-mainnet.g.alchemy.com/v2/${providerApiKey}`,
+      url: \`https://polygonzkevm-mainnet.g.alchemy.com/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     polygonZkEvmTestnet: {
-      url: `https://polygonzkevm-testnet.g.alchemy.com/v2/${providerApiKey}`,
+      url: \`https://polygonzkevm-testnet.g.alchemy.com/v2/\${providerApiKey}\`,
       accounts: [deployerPrivateKey],
     },
     gnosis: {
@@ -121,12 +124,12 @@ const config: HardhatUserConfig = {
   },
   // configuration for harhdat-verify plugin
   etherscan: {
-    apiKey: `${etherscanApiKey}`,
+    apiKey: \`\${etherscanApiKey}\`,
   },
   // configuration for etherscan-verify from hardhat-deploy plugin
   verify: {
     etherscan: {
-      apiKey: `${etherscanApiKey}`,
+      apiKey: \`\${etherscanApiKey}\`,
     },
   },
   sourcify: {
@@ -134,4 +137,8 @@ const config: HardhatUserConfig = {
   },
 };
 
-export default config;
+export default config;`;
+
+export default withDefaults(contents, {
+  otherImports: "",
+});


### PR DESCRIPTION
### Description: 
- templatise tailwind light and dark theme
  - this allow people to give SE-2 colors of their choice
- allow importing more stuff in hardhat.config.ts
   - Since hardhat requires something to be present in `hardhat.config.ts` for example [plugins](https://hardhat.org/hardhat-runner/plugins#community-plugins)
   - another example is exposing [tasks](https://hardhat.org/hardhat-runner/docs/advanced/create-task) 

### Test: 
1. use latest cli changes
```shell
yarn dev
```

2. Create a test instance: 

```shell
yarn cli ../test-my-new-extension -e technophile-04/tailwind-hardhat-tasks-extension
```
I have created [technophile-04/tailwind-hardhat-tasks-extension ](https://github.com/technophile-04/tailwind-hardhat-tasks-extension/) this extension which uses hardhat tasks and updates tailwind theme. 

3. Go to directory : 

```shell
cd ../test-my-new-extension
```

4. To check hardhat tasks: 
```shell
cd packages/hardhat && yarn hardhat sayHello
```
^ the above should pring "Hello, World!"

5. Checkout the theme by doing `yarn start`