### PR TITLE
Add template support for solidityVersion, networks and tailwind extend

### DIFF
--- a/.changeset/shiny-papayas-hide.md
+++ b/.changeset/shiny-papayas-hide.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+Allow solidity versions and networks + tailwind extend theme

--- a/templates/base/packages/nextjs/tailwind.config.js.template.mjs
+++ b/templates/base/packages/nextjs/tailwind.config.js.template.mjs
@@ -19,7 +19,7 @@ module.exports = {
   },
   theme: {
     extend: {
-      ${extendTheme[0] && `${extendTheme},`}
+      ${extendTheme[0] && `${extendTheme[0]},`}
       boxShadow: {
         center: "0 0 12px -2px rgb(0 0 0 / 0.05)",
       },

--- a/templates/base/packages/nextjs/tailwind.config.js.template.mjs
+++ b/templates/base/packages/nextjs/tailwind.config.js.template.mjs
@@ -19,7 +19,7 @@ module.exports = {
   },
   theme: {
     extend: {
-      ${extendTheme},
+      ${extendTheme[0] && `${extendTheme},`}
       boxShadow: {
         center: "0 0 12px -2px rgb(0 0 0 / 0.05)",
       },

--- a/templates/base/packages/nextjs/tailwind.config.js.template.mjs
+++ b/templates/base/packages/nextjs/tailwind.config.js.template.mjs
@@ -1,6 +1,6 @@
 import { withDefaults } from "../../../utils.js";
 
-const contents = ({ lightTheme, darkTheme }) => `/** @type {import('tailwindcss').Config} */
+const contents = ({ lightTheme, darkTheme, extendTheme }) => `/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}", "./utils/**/*.{js,ts,jsx,tsx}"],
   plugins: [require("daisyui")],
@@ -19,6 +19,7 @@ module.exports = {
   },
   theme: {
     extend: {
+      ${extendTheme},
       boxShadow: {
         center: "0 0 12px -2px rgb(0 0 0 / 0.05)",
       },
@@ -91,4 +92,5 @@ export default withDefaults(contents, {
             opacity: "80%",
           },
         }`,
+  extendTheme: "",
 });

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -41,7 +41,7 @@ const config: HardhatUserConfig = {
     },
   },
   networks: {
-    ${networks[0] && `${networks},`}
+    ${networks[0] && `${networks[0]},`}
     // View the networks that are pre-configured.
     // If the network you are looking for is not here you can add new network settings
     hardhat: {

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -24,7 +24,7 @@ const etherscanApiKey = process.env.ETHERSCAN_API_KEY || "DNXJA8RX2Q3VZ4URQIWP7Z
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "${solidityVersion}",
+    version: "${solidityVersion[0]}",
     settings: {
       optimizer: {
         enabled: true,
@@ -41,7 +41,7 @@ const config: HardhatUserConfig = {
     },
   },
   networks: {
-    ${networks},
+    ${networks[0] && `${networks},`}
     // View the networks that are pre-configured.
     // If the network you are looking for is not here you can add new network settings
     hardhat: {

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -1,6 +1,6 @@
 import { withDefaults } from "../../../../utils.js";
 
-const contents = ({ imports }) => `import * as dotenv from "dotenv";
+const contents = ({ imports, solidityVersion, networks }) => `import * as dotenv from "dotenv";
 dotenv.config();
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-ethers";
@@ -24,7 +24,7 @@ const etherscanApiKey = process.env.ETHERSCAN_API_KEY || "DNXJA8RX2Q3VZ4URQIWP7Z
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.17",
+    version: "${solidityVersion}",
     settings: {
       optimizer: {
         enabled: true,
@@ -41,6 +41,7 @@ const config: HardhatUserConfig = {
     },
   },
   networks: {
+    ${networks},
     // View the networks that are pre-configured.
     // If the network you are looking for is not here you can add new network settings
     hardhat: {
@@ -141,4 +142,6 @@ export default config;`;
 
 export default withDefaults(contents, {
   imports: "",
+  solidityVersion: "0.8.17",
+  networks: "",
 });


### PR DESCRIPTION
Since we already have those files (hardhat & tailwind config) on a template, I wonder if we should add some handy stuff.

- Solidity version
- Networks
- Tailwind extend theme

You can test with https://github.com/carletex/create-eth-extensions/tree/tailwind-extend-solidity-version

```
yarn cli -e carletex/create-eth-extensions:tailwind-extend-solidity-version
```

What do you think?

(I'll add the changeset if we like this)