### PR TITLE
yarn install output

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,5 @@
-import {
-  copyTemplateFiles,
-  createProjectDirectory,
-  installPackages,
-  createFirstGitCommit,
-  prettierFormat,
-} from "./tasks";
+import { copyTemplateFiles, createProjectDirectory, createFirstGitCommit, prettierFormat } from "./tasks";
+import { execaCommand as command } from "execa";
 import type { Options } from "./types";
 import { renderOutroMessage } from "./utils/render-outro-message";
 import chalk from "chalk";
@@ -36,6 +31,68 @@ export async function createProject(options: Options) {
         task: () => copyTemplateFiles(options, templateDirectory, targetDirectory),
       },
       {
+        title: "📦 Installing dependencies with yarn, this could take a while",
+        task: async (_, task): Promise<void> => {
+          const execute = command("yarn install", { cwd: targetDirectory });
+
+          let outputBuffer: string = ""; // Buffer to store output characters
+
+          const maxChunks = 1; // Define the number of chunks to display
+          const chunkSize = 1024; // Define the size of each chunk (1KB here)
+
+          // Handle stdout
+          execute?.stdout?.on("data", (data: Buffer) => {
+            outputBuffer += data.toString(); // Append data to the buffer
+
+            // Ensure the buffer doesn't exceed the size of maxChunks * chunkSize
+            if (outputBuffer.length > maxChunks * chunkSize) {
+              outputBuffer = outputBuffer.slice(-maxChunks * chunkSize); // Keep only the last N chunks
+            }
+
+            // Add a forced newline if needed (this makes it friendly to Listr2)
+            const visibleOutput =
+              outputBuffer
+                .match(new RegExp(`.{1,${chunkSize}}`, "g")) // Split into chunks
+                ?.slice(-maxChunks) // Keep only the last N chunks
+                .map(chunk => chunk.trimEnd() + "\n") // Ensure each chunk ends with a newline
+                .join("") ?? outputBuffer;
+
+            task.output = visibleOutput; // Set the trimmed and formatted output
+          });
+
+          // Handle stderr similarly
+          execute?.stderr?.on("data", (data: Buffer) => {
+            outputBuffer += data.toString();
+
+            if (outputBuffer.length > maxChunks * chunkSize) {
+              outputBuffer = outputBuffer.slice(-maxChunks * chunkSize);
+            }
+
+            const visibleOutput =
+              outputBuffer
+                .match(new RegExp(`.{1,${chunkSize}}`, "g")) // Split into chunks
+                ?.slice(-maxChunks)
+                .map(chunk => chunk.trimEnd() + "\n") // Force a newline at the end of each chunk
+                .join("") ?? outputBuffer;
+
+            task.output = visibleOutput;
+          });
+
+          await execute;
+        },
+        skip: () => {
+          if (!options.install) {
+            return "Manually skipped, since `--skip-install` flag was passed";
+          }
+          return false;
+        },
+
+        rendererOptions: {
+          outputBar: 8, // Optional, adjust for your needs
+          persistentOutput: false,
+        },
+      },
+      /* {
         title: `📦 Installing dependencies with yarn, this could take a while`,
         task: () => installPackages(targetDirectory),
         skip: () => {
@@ -44,7 +101,7 @@ export async function createProject(options: Options) {
           }
           return false;
         },
-      },
+      }, */
       {
         title: "🪄 Formatting files",
         task: () => prettierFormat(targetDirectory),


### PR DESCRIPTION
### Description: 

> NOTE: This is not a final PR and will update the code but just trying to get a vibe on it

This might go to trash and completely fine with it 🙌 but had this idea in mind that if we want to hint user something is going on probably showing yarn install output is good idea? 


https://github.com/user-attachments/assets/3833c652-93a2-40dd-bbe4-b8d3d786a545

We could also make it more interactive like 2 min has passed and task is not done yet we log the output "Seems like its taking longer than usual..." 

Last time I tried achieving in simple way it was not woking due to how `yarn` logs output to terminal at some places without `\n` but this time thanks to gpt-4o I got it working seems to work. 
