### PR TITLE
Add template support for solidity configuration

### DIFF
--- a/.changeset/nervous-walls-agree.md
+++ b/.changeset/nervous-walls-agree.md
@@ -1,0 +1,5 @@
+---
+"create-eth": minor
+---
+
+Add template support for solidity configuration

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -1,6 +1,6 @@
 import { withDefaults } from "../../../../utils.js";
 
-const contents = ({ imports, solidityVersion, networks }) => `import * as dotenv from "dotenv";
+const contents = ({ imports, solidity, networks }) => `import * as dotenv from "dotenv";
 dotenv.config();
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-ethers";
@@ -23,16 +23,7 @@ const deployerPrivateKey =
 const etherscanApiKey = process.env.ETHERSCAN_API_KEY || "DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW";
 
 const config: HardhatUserConfig = {
-  solidity: {
-    version: "${solidityVersion[0]}",
-    settings: {
-      optimizer: {
-        enabled: true,
-        // https://docs.soliditylang.org/en/latest/using-the-compiler.html#optimizer-options
-        runs: 200,
-      },
-    },
-  },
+  ${solidity[0]}
   defaultNetwork: "localhost",
   namedAccounts: {
     deployer: {
@@ -142,6 +133,15 @@ export default config;`;
 
 export default withDefaults(contents, {
   imports: "",
-  solidityVersion: "0.8.17",
+  solidity: `solidity: {
+    version: "0.8.17",
+    settings: {
+      optimizer: {
+        enabled: true,
+        // https://docs.soliditylang.org/en/latest/using-the-compiler.html#optimizer-options
+        runs: 200,
+      },
+    },
+  },`,
   networks: "",
 });


### PR DESCRIPTION
Hey guys,

This PR extends the **hardhat.config.ts.template.mjs** template.

Currently we can change the solidity version, however [solidity configuration ](https://hardhat.org/hardhat-runner/docs/config#solidity-configuration) has more options.

I started experimenting with a uniswap-v2 extension, the uniswap contracts need an older compiler version, so I'd need to use multiple compilers.

With this current change I was able to create an [extension](https://github.com/moltam89/uniswap-v2/blob/main/extension/packages/hardhat/hardhat.config.ts.args.mjs) with multiple compilers.

Let me know what do you think.

Thanks,
Tamas
