### PR TITLE
process example solidity template only when required

### DIFF
--- a/.changeset/friendly-boats-fix.md
+++ b/.changeset/friendly-boats-fix.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+fix: processing solidity-example template

--- a/src/tasks/copy-template-files.ts
+++ b/src/tasks/copy-template-files.ts
@@ -360,11 +360,19 @@ export async function copyTemplateFiles(options: Options, templateDir: string, t
     await copyExtensionFiles(options, externalExtensionPath, targetDir);
   }
 
-  if (!options.externalExtension && options.solidityFramework && exampleContractsPath) {
+  const shouldCopyExampleContracts = !options.externalExtension && options.solidityFramework && exampleContractsPath;
+  if (shouldCopyExampleContracts) {
     await copyExtensionFiles(options, exampleContractsPath, targetDir);
   }
+
   // 4. Process templated files and generate output
-  await processTemplatedFiles(options, basePath, solidityFrameworkPath, exampleContractsPath, targetDir);
+  await processTemplatedFiles(
+    options,
+    basePath,
+    solidityFrameworkPath,
+    shouldCopyExampleContracts ? exampleContractsPath : null,
+    targetDir,
+  );
 
   // 5. Delete tmp directory
   if (options.externalExtension && !options.dev) {

--- a/templates/solidity-frameworks/foundry/packages/foundry/test/YourContract.t.sol
+++ b/templates/solidity-frameworks/foundry/packages/foundry/test/YourContract.t.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import "../contracts/YourContract.sol";
+// import "../contracts/YourContract.sol";
 
 contract YourContractTest is Test {
-  YourContract public yourContract;
+/* YourContract public yourContract;
 
   function setUp() public {
     yourContract = new YourContract(vm.addr(1));
@@ -16,13 +16,5 @@ contract YourContractTest is Test {
       keccak256(bytes(yourContract.greeting()))
         == keccak256("Building Unstoppable Apps!!!")
     );
-  }
-
-  function testSetNewMessage() public {
-    yourContract.setGreeting("Learn Scaffold-ETH 2! :)");
-    require(
-      keccak256(bytes(yourContract.greeting()))
-        == keccak256("Learn Scaffold-ETH 2! :)")
-    );
-  }
+  } */
 }


### PR DESCRIPTION
### Description : 

Earlier it was processing the exampleSolidityContract path always causing the extensions to break like `erc-20` when foundry was chosen. 

```shell
npx create-eth@latest -e erc-20 -s foundry
``` 

^ This breaks. 

### To test: 

Switch to this branch and then: 

```shell
yarn dev
```

```shell
yarn cli -e erc-20 -s foundry
```