### PR TITLE
Add warning for deleted files to prevent errors during processing

### DIFF
--- a/.changeset/spotty-fans-occur.md
+++ b/.changeset/spotty-fans-occur.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+Add warning for deleted files to prevent errors during processing

--- a/.changeset/spotty-fans-occur.md
+++ b/.changeset/spotty-fans-occur.md
@@ -1,5 +1,0 @@
----
-"create-eth": patch
----
-
-Add warning for deleted files to prevent errors during processing

--- a/src/dev/create-extension.ts
+++ b/src/dev/create-extension.ts
@@ -84,6 +84,12 @@ const copyFiles = async (files: string[], projectName: string, projectPath: stri
     const destPath = path.join(EXTERNAL_EXTENSIONS_DIR, projectName, TARGET_EXTENSION_DIR, file);
     const sourceFileName = path.basename(sourcePath);
 
+    if (!fs.existsSync(sourcePath)) {
+      prettyLog.warning(`Source file not found, skipping: ${file}`, 2);
+      console.log("\n");
+      continue;
+    }
+
     if (templates.has(file)) {
       prettyLog.warning(`Skipping file: ${file}`, 2);
       prettyLog.info(`Please instead create/update: ${destPath}.args.mjs`, 3);

--- a/src/dev/create-extension.ts
+++ b/src/dev/create-extension.ts
@@ -85,13 +85,12 @@ const findTemplateFiles = async (dir: string, templates: Set<string>) => {
 };
 
 const copyFiles = async (
-  files: string[],
+  changedFiles: string[],
   deletedFiles: string[],
   projectName: string,
   projectPath: string,
   templates: Set<string>,
 ) => {
-  // First handle deletions
   for (const file of deletedFiles) {
     const destPath = path.join(EXTERNAL_EXTENSIONS_DIR, projectName, TARGET_EXTENSION_DIR, file);
     if (fs.existsSync(destPath)) {
@@ -99,7 +98,7 @@ const copyFiles = async (
       prettyLog.success(`Removed deleted file: ${file}`, 2);
       console.log("\n");
 
-      // Optionally remove empty directories
+      // remove empty directories
       const dirPath = path.dirname(destPath);
       try {
         const remainingFiles = await fs.promises.readdir(dirPath);
@@ -109,12 +108,12 @@ const copyFiles = async (
           console.log("\n");
         }
       } catch {
-        // Directory might already be deleted, ignore error
+        // directory might already be deleted, ignore error
       }
     }
   }
 
-  for (const file of files) {
+  for (const file of changedFiles) {
     const pathSegmentsOfFile = file.split(path.sep);
     const sourcePath = path.resolve(projectPath, file);
     const destPath = path.join(EXTERNAL_EXTENSIONS_DIR, projectName, TARGET_EXTENSION_DIR, file);

--- a/src/dev/create-extension.ts
+++ b/src/dev/create-extension.ts
@@ -39,12 +39,12 @@ const getProjectPath = (rawArgs: string[]) => {
 
 const getDiffFilesFromFirstCommit = async ({
   projectPath,
-  diffFilter,
+  isDeleted = false,
 }: {
   projectPath: string;
-  diffFilter?: "d" | "D";
+  isDeleted?: boolean;
 }): Promise<string[]> => {
-  if (diffFilter === "D") {
+  if (isDeleted) {
     // all files that have ever existed in the repo's history
     const { stdout: allFiles } = await execa(
       "git",
@@ -66,8 +66,7 @@ const getDiffFilesFromFirstCommit = async ({
     cwd: projectPath,
   });
 
-  const diffFilterArg = diffFilter ? `--diff-filter=${diffFilter}` : "";
-  const { stdout } = await execa("git", ["diff", diffFilterArg, "--name-only", `${firstCommit.trim()}..HEAD`], {
+  const { stdout } = await execa("git", ["diff", "--diff-filter=d", "--name-only", `${firstCommit.trim()}..HEAD`], {
     cwd: projectPath,
   });
 
@@ -211,8 +210,8 @@ const main = async (rawArgs: string[]) => {
     prettyLog.info(`Extension name: ${projectName}\n`);
 
     prettyLog.info("Getting list of changed files...", 1);
-    const changedFiles = await getDiffFilesFromFirstCommit({ projectPath, diffFilter: "d" });
-    const deletedFiles = await getDiffFilesFromFirstCommit({ projectPath, diffFilter: "D" });
+    const changedFiles = await getDiffFilesFromFirstCommit({ projectPath });
+    const deletedFiles = await getDiffFilesFromFirstCommit({ projectPath, isDeleted: true });
 
     if (changedFiles.length === 0 && deletedFiles.length === 0) {
       prettyLog.warning("No changed files to copy.", 1);


### PR DESCRIPTION
Hey guys,

I was working on an extension, where I deleted the default `YourContract.sol` file, which resulted in an error when I tried to use `yarn create-extension {projectName}`.

**Steps to reproduce:**
1. yarn cli
2. Delete e.g. the YourContract.sol file
3. yarn create-extension {projectName}

![Screenshot 2024-12-03 at 17 02 20](https://github.com/user-attachments/assets/abc97464-cdde-431d-adc9-7b426b1064f1)

After this fix it should work like this:

![Screenshot 2024-12-03 at 17 08 10](https://github.com/user-attachments/assets/6409026a-689b-4631-b753-57ddfa6f5ce9)

