### PR TITLE
Format package.json files

### DIFF
--- a/.changeset/thirty-hairs-crash.md
+++ b/.changeset/thirty-hairs-crash.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+Format package.json files

--- a/src/utils/merge-package-json.ts
+++ b/src/utils/merge-package-json.ts
@@ -14,7 +14,9 @@ export function mergePackageJson(targetPackageJsonPath: string, secondPackageJso
 
   const mergedPkgStr = mergeJsonStr.default(targetPackageJson, secondPackageJson);
 
-  fs.writeFileSync(targetPackageJsonPath, mergedPkgStr, "utf8");
+  const formattedPkgStr = JSON.stringify(JSON.parse(mergedPkgStr), null, 2);
+
+  fs.writeFileSync(targetPackageJsonPath, formattedPkgStr, "utf8");
   if (isDev) {
     const devStr = `TODO: write relevant information for the contributor`;
     fs.writeFileSync(`${targetPackageJsonPath}.dev`, devStr, "utf8");


### PR DESCRIPTION
Hey guys,

This is a small enhancement to help the development workflow.

When testing an extension locally with `yarn cli -e {projectName} --dev --skip`, all the **package.json** files are squashed into 1 line.  
With this fix, the `package.json` files will look normal.

I created a [testJSON](https://github.com/moltam89/testJSON/) repo where there are actual changes in the main `package.json` file, but this issue should be reproducible with any extension.

**Note:**  
This is not a problem when we use an extension from GitHub, because the original file's formatting is preserved. So in the case of `yarn cli -e moltam89/testJSON --skip`, the `package.json` files will look okay.

Cheers,  
Tamas
