### PR TITLE
Do not copy/link .DS_Store files - macOS only

### DIFF
--- a/.changeset/rude-insects-compete.md
+++ b/.changeset/rude-insects-compete.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+Do not copy/link .DS_Store files - macOS only

--- a/src/tasks/copy-template-files.ts
+++ b/src/tasks/copy-template-files.ts
@@ -24,6 +24,7 @@ const isArgsRegex = /([^/\\]*?)\.args\./;
 const isSolidityFrameworkFolderRegex = /solidity-frameworks$/;
 const isPackagesFolderRegex = /packages$/;
 const isDeployedContractsRegex = /packages\/nextjs\/contracts\/deployedContracts\.ts/;
+const isDSStoreRegex = /\.DS_Store$/;
 
 const getSolidityFrameworkPath = (solidityFramework: SolidityFramework, templatesDirectory: string) =>
   path.resolve(templatesDirectory, SOLIDITY_FRAMEWORKS_DIR, solidityFramework);
@@ -39,7 +40,9 @@ const copyBaseFiles = async (basePath: string, targetDir: string, { dev: isDev }
       const isPackageJson = isPackageJsonRegex.test(fileName);
       const skipDevOnly = isDev && (isYarnLock || isDeployedContracts || isPackageJson);
 
-      return !isTemplate && !skipDevOnly;
+      const isDSStore = isDSStoreRegex.test(fileName);
+
+      return !isTemplate && !skipDevOnly && !isDSStore;
     },
   });
 
@@ -81,8 +84,9 @@ const copyExtensionFiles = async (
       const isTemplate = isTemplateRegex.test(path);
       // PR NOTE: this wasn't needed before because ncp had the clobber: false
       const isPackageJson = isPackageJsonRegex.test(path);
+      const isDSStore = isDSStoreRegex.test(path);
       const shouldSkip =
-        isConfig || isArgs || isTemplate || isPackageJson || isSolidityFrameworkFolder || isPackagesFolder;
+        isConfig || isArgs || isTemplate || isPackageJson || isSolidityFrameworkFolder || isPackagesFolder || isDSStore;
       return !shouldSkip;
     },
   });
@@ -100,6 +104,7 @@ const copyExtensionFiles = async (
         const isArgs = isArgsRegex.test(path);
         const isTemplate = isTemplateRegex.test(path);
         const isPackageJson = isPackageJsonRegex.test(path);
+        const isDSStore = isDSStoreRegex.test(path);
 
         const unselectedSolidityFrameworks = [SOLIDITY_FRAMEWORKS.FOUNDRY, SOLIDITY_FRAMEWORKS.HARDHAT].filter(
           sf => sf !== solidityFramework,
@@ -107,7 +112,7 @@ const copyExtensionFiles = async (
         const isUnselectedSolidityFrameworksRegexes = unselectedSolidityFrameworks.map(sf => new RegExp(`${sf}$`));
         const isUnselectedSolidityFramework = isUnselectedSolidityFrameworksRegexes.some(sfregex => sfregex.test(path));
 
-        const shouldSkip = isArgs || isTemplate || isPackageJson || isUnselectedSolidityFramework;
+        const shouldSkip = isArgs || isTemplate || isPackageJson || isUnselectedSolidityFramework || isDSStore;
 
         return !shouldSkip;
       },


### PR DESCRIPTION
Hey guys,

This is a `macOS` only issue, which was driving me mad, because it seemed to happen randomly and I had to always clean my whole repo with `git clean -fxd` to bypass it.

It should be reproducible with any extensions, I used my [UniswapX-extension](https://github.com/moltam89/UniswapX-extension) for testing:

Open `templates/base` and `templates/solidity-frameworks/hardhat` with the Finder app.
Make sure (`ls -a`) that `.DS_Store` files were generated. (I still don't know when these files are generated exactly, sometimes I had to jump in and out of the folder a few times)

`yarn build:dev && yarn cli -e UniswapX-extension --dev --skip fromUniswap`

![Screenshot 2024-12-15 at 13 34 24](https://github.com/user-attachments/assets/e66a2621-f745-4459-94f4-54a5d30ad6d4)

Cheers,
Tamas
