### PR TITLE
tinker: template config objects more customisation

### DIFF
--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -1,120 +1,102 @@
-import { withDefaults } from "../../../../utils.js";
+import { withDefaults, stringify } from "../../../../utils.js";
 
-const contents = ({ imports, solidityVersion, networks, compilers }) => {
+function deepMerge(target, ...sources) {
+  if (!sources.length) return target;
+  const source = sources.shift();
 
-  const massagedCompilers = compilers[0]?.[0] ? JSON.stringify(compilers[0]) : '';
-  
-  const defaultCompilers = `[
-  {
-    version: "${solidityVersion[0]}",
-    settings: {
-      optimizer: {
-        enabled: true,
-        // https://docs.soliditylang.org/en/latest/using-the-compiler.html#optimizer-options
-        runs: 200,
-      },
-    },
-  },
-]`;
+  if (source && typeof source === 'object') {
+    for (const key in source) {
+      if (source[key] && typeof source[key] === 'object') {
+        if (!target[key]) {
+          target[key] = Array.isArray(source[key]) ? [] : {};
+        }
+        deepMerge(target[key], source[key]);
+      } else {
+        target[key] = source[key];
+      }
+    }
+  }
 
-return `import * as dotenv from "dotenv";
-dotenv.config();
-import { HardhatUserConfig } from "hardhat/config";
-import "@nomicfoundation/hardhat-ethers";
-import "@nomicfoundation/hardhat-chai-matchers";
-import "@typechain/hardhat";
-import "hardhat-gas-reporter";
-import "solidity-coverage";
-import "@nomicfoundation/hardhat-verify";
-import "hardhat-deploy";
-import "hardhat-deploy-ethers";
-import { task } from "hardhat/config";
-import generateTsAbis from "./scripts/generateTsAbis";
-${imports.filter(Boolean).join("\n")}
+  return deepMerge(target, ...sources);
+}
 
-// If not set, it uses ours Alchemy's default API key.
-// You can get your own at https://dashboard.alchemyapi.io
-const providerApiKey = process.env.ALCHEMY_API_KEY || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
-// If not set, it uses the hardhat account 0 private key.
-// You can generate a random account with \`yarn generate\` or \`yarn account:import\` to import your existing PK
-const deployerPrivateKey =
-  process.env.__RUNTIME_DEPLOYER_PRIVATE_KEY ?? "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-// If not set, it uses our block explorers default API keys.
-const etherscanApiKey = process.env.ETHERSCAN_MAINNET_API_KEY || "DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW";
-const etherscanOptimisticApiKey = process.env.ETHERSCAN_OPTIMISTIC_API_KEY || "RM62RDISS1RH448ZY379NX625ASG1N633R";
-const basescanApiKey = process.env.BASESCAN_API_KEY || "ZZZEIPMT1MNJ8526VV2Y744CA7TNZR64G6";
-
-const config: HardhatUserConfig = {
+const defaultConfig = {
   solidity: {
-    compilers: ${massagedCompilers || defaultCompilers}
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ]
   },
   defaultNetwork: "localhost",
   namedAccounts: {
     deployer: {
-      // By default, it will take the first Hardhat account as the deployer
       default: 0,
     },
   },
   networks: {
-    ${networks[0] && `${networks[0]},`}
-    // View the networks that are pre-configured.
-    // If the network you are looking for is not here you can add new network settings
     hardhat: {
       forking: {
-        url: \`https://eth-mainnet.alchemyapi.io/v2/\${providerApiKey}\`,
+        url: `https://eth-mainnet.alchemyapi.io/v2/\${providerApiKey}`,
         enabled: process.env.MAINNET_FORKING_ENABLED === "true",
       },
     },
     mainnet: {
-      url: \`https://eth-mainnet.alchemyapi.io/v2/\${providerApiKey}\`,
+      url: `https://eth-mainnet.alchemyapi.io/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     sepolia: {
-      url: \`https://eth-sepolia.g.alchemy.com/v2/\${providerApiKey}\`,
+      url: `https://eth-sepolia.g.alchemy.com/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     arbitrum: {
-      url: \`https://arb-mainnet.g.alchemy.com/v2/\${providerApiKey}\`,
+      url: `https://arb-mainnet.g.alchemy.com/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     arbitrumSepolia: {
-      url: \`https://arb-sepolia.g.alchemy.com/v2/\${providerApiKey}\`,
+      url: `https://arb-sepolia.g.alchemy.com/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     optimism: {
-      url: \`https://opt-mainnet.g.alchemy.com/v2/\${providerApiKey}\`,
+      url: `https://opt-mainnet.g.alchemy.com/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
       verify: {
         etherscan: {
           apiUrl: "https://api-optimistic.etherscan.io",
-          apiKey: etherscanOptimisticApiKey,
+          apiKey: "etherscanOptimisticApiKey",
         },
       },
     },
     optimismSepolia: {
-      url: \`https://opt-sepolia.g.alchemy.com/v2/\${providerApiKey}\`,
+      url: `https://opt-sepolia.g.alchemy.com/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
       verify: {
         etherscan: {
           apiUrl: "https://api-sepolia-optimistic.etherscan.io",
-          apiKey: etherscanOptimisticApiKey,
+          apiKey: "etherscanOptimisticApiKey",
         },
       },
     },
     polygon: {
-      url: \`https://polygon-mainnet.g.alchemy.com/v2/\${providerApiKey}\`,
+      url: `https://polygon-mainnet.g.alchemy.com/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     polygonMumbai: {
-      url: \`https://polygon-mumbai.g.alchemy.com/v2/\${providerApiKey}\`,
+      url: `https://polygon-mumbai.g.alchemy.com/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     polygonZkEvm: {
-      url: \`https://polygonzkevm-mainnet.g.alchemy.com/v2/\${providerApiKey}\`,
+      url: `https://polygonzkevm-mainnet.g.alchemy.com/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     polygonZkEvmTestnet: {
-      url: \`https://polygonzkevm-testnet.g.alchemy.com/v2/\${providerApiKey}\`,
+      url: `https://polygonzkevm-testnet.g.alchemy.com/v2/\${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     gnosis: {
@@ -131,7 +113,7 @@ const config: HardhatUserConfig = {
       verify: {
         etherscan: {
           apiUrl: "https://api.basescan.org",
-          apiKey: basescanApiKey,
+          apiKey: "basescanApiKey",
         },
       },
     },
@@ -141,7 +123,7 @@ const config: HardhatUserConfig = {
       verify: {
         etherscan: {
           apiUrl: "https://api-sepolia.basescan.org",
-          apiKey: basescanApiKey,
+          apiKey: "basescanApiKey",
         },
       },
     },
@@ -170,20 +152,55 @@ const config: HardhatUserConfig = {
       accounts: [deployerPrivateKey],
     },
   },
-  // configuration for harhdat-verify plugin
   etherscan: {
-    apiKey: \`\${etherscanApiKey}\`,
+    apiKey: `\${etherscanApiKey}`,
   },
-  // configuration for etherscan-verify from hardhat-deploy plugin
   verify: {
     etherscan: {
-      apiKey: \`\${etherscanApiKey}\`,
+      apiKey: `\${etherscanApiKey}`,
     },
   },
   sourcify: {
     enabled: false,
   },
 };
+
+const contents = ({ preConfigContent, configOverride }) => {
+  // Merge the default config with any overrides
+  const finalConfig = deepMerge({}, defaultConfig);
+  
+  if (configOverride) {
+    deepMerge(finalConfig, configOverride);
+  }
+
+  return `import * as dotenv from "dotenv";
+dotenv.config();
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-ethers";
+import "@nomicfoundation/hardhat-chai-matchers";
+import "@typechain/hardhat";
+import "hardhat-gas-reporter";
+import "solidity-coverage";
+import "@nomicfoundation/hardhat-verify";
+import "hardhat-deploy";
+import "hardhat-deploy-ethers";
+import { task } from "hardhat/config";
+import generateTsAbis from "./scripts/generateTsAbis";
+${preConfigContent[0] || ''}
+
+// If not set, it uses ours Alchemy's default API key.
+// You can get your own at https://dashboard.alchemyapi.io
+const providerApiKey = process.env.ALCHEMY_API_KEY || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
+// If not set, it uses the hardhat account 0 private key.
+// You can generate a random account with \`yarn generate\` or \`yarn account:import\` to import your existing PK
+const deployerPrivateKey =
+  process.env.__RUNTIME_DEPLOYER_PRIVATE_KEY ?? "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+// If not set, it uses our block explorers default API keys.
+const etherscanApiKey = process.env.ETHERSCAN_MAINNET_API_KEY || "DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW";
+const etherscanOptimisticApiKey = process.env.ETHERSCAN_OPTIMISTIC_API_KEY || "RM62RDISS1RH448ZY379NX625ASG1N633R";
+const basescanApiKey = process.env.BASESCAN_API_KEY || "ZZZEIPMT1MNJ8526VV2Y744CA7TNZR64G6";
+
+const config: HardhatUserConfig = ${stringify(finalConfig)};
 
 // Extend the deploy task
 task("deploy").setAction(async (args, hre, runSuper) => {
@@ -193,14 +210,10 @@ task("deploy").setAction(async (args, hre, runSuper) => {
   await generateTsAbis(hre);
 });
 
-export default config;`
+export default config;`;
 };
 
 export default withDefaults(contents, {
-  imports: "",
-  solidityVersion: "0.8.20",
-  networks: "",
-  // set solidity compilers
-  // https://hardhat.org/hardhat-runner/docs/advanced/multiple-solidity-versions#multiple-solidity-versions
-  compilers: [],
+  preConfigContent: "",
+  configOverrides: {},
 });


### PR DESCRIPTION
> NOTE: This is more like a discussion, brainstorming PR and will create a PR for other files which doesn't have variable in object in them. But we will encounter this problem in future as well 

### Goal: 

The goal was to allow more customization for templates file (specially for this PR, templates which have config object like structure) 

Was planning to have just two args for this config object like template 
1. `preConfigContent` (type: string code snippet) => Allows developer to add imports/custom pre config object setup logic if they want
2.  `configObj` (type: Object) => This object will be merged with default SE-2 config object. 


### Problem: 

When having config objects whose key values are `variable`  which comes from `preConfigContent` code snippet, we can't seem to access it during runtime and CLI errors out. 

For eg: checkout this PR file changes `hardhat.config.template.mjs`. Since `deployerPrivateKey` is variable which comes from  `preConfigContent` code snippet (its string) while resolving that object, node js runtime doesn't have any idea about `deployerPrivateKey` in the object and it errors out. 

Example error: `yarn build && yarn cli ../test-blah -s hardhat --skip` : 

<details>

<summary>
    Error image: 
</summary>

   
<img width="1509" alt="Screenshot 2024-12-19 at 5 35 13 PM" src="https://github.com/user-attachments/assets/b3b77f90-0795-4dd1-b661-e1fbe2acbc13" />


</details>

*Similarly, if people create a `.arg.mjs` which has a uses certain variable in `configObj` then CLI will error again too. 

<details>

<summary>
    Example `hardhat.config.ts.args.mjs`
</summary>

  ```ts
  export const preConfigContent = `
  // Custom variables
  const CUSTOM_API_KEY = process.env.CUSTOM_API_KEY;
  `;
  
  export const configOverride = {
  networks: {
    hardhat: {
      forking: {
        blockNumber: 1234567
      }
    },
    customNetwork: {
      url: "https://custom.network",
      accounts: [deployerPrivateKey],
      verify: {
        etherscan: {
          apiUrl: "https://api.custom-explorer.io",
          apiKey: etherscanApiKey,
        }
      }
    }
  },
  };

  ```

</details> 

We are getting `ReferenceErrror: deployerPrivateKey not defined` because that variable isn't present in JS scope/context. 

### Hacky solution explored: 

Didn't find any good solutions to this, found a very hacky solution but not sure if we should go with it or not and make it completely working. 


<details>

<summary>
Injecting this "not defined" variables in JS context virtually on run time. 
</summary>


Checkout this very hacky code snippet which tries to inject not defined variables in context for `.args.mjs` file (thanks to claude): 

https://github.com/scaffold-eth/create-eth/blob/2ee1b9e03ea52ab90a642dbdc178470481076c24/src/tasks/copy-template-files.ts#L44-L98


This still doesn't does the job completely since in final merged `hardhat.config.ts` you would that variables are still wrapped around quotes from `hardhat-config` extension but at least its able to parse `.arg.mjs` without CLI erroring out. 

Need to handle `.template.mjs` still and its getting hard messy to inject context for this file. 


### Incase you want to test: 




1. Clone the this repo in `externalExtensions` dir : 

```shell
git clone https://github.com/technophile-04/hardhat-config
```

2. Switch to `tinker-object-merge-v2` branch: 

```shell
git switch tinker-object-merge-v2
```

3. yarn build and create a example instance: 

```shell
yarn build && yarn cli ../test-blah -s hardhat -e hardhat-config --dev --skip
```

</details>


### Other simple solution but not better DX: 

We tell people to whenever they want to access the variable in object from `preConfigContent` snippet or SE-2 template instead of directly passing raw variable they pass string with certain special character like: 'account: ["$$${deployerPrivateKey}"]'.  and in templating logic we can may strip that special character somehow. 


NOTE: If an object has a comment it won't be present in the final merged config file. 


--- 

I think initially while developing this templating engine we thought only strings would be passed but when objects are passed its  like we have to come with hacky solutions and do some massaging as we had to do it here too https://github.com/scaffold-eth/create-eth/pull/145/files#r1850908537

Would love if anyone has better idea/suggestion 🙌

