### PR TITLE
Fix merge package.json files

### DIFF
--- a/.changeset/tame-donuts-thank.md
+++ b/.changeset/tame-donuts-thank.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+cli: fix merge package.json files for extensions with both solidity-frameworks


### PR DESCRIPTION
If you have `package.json` files in both `hardhat` and `foundry` folders of your extension, installation breaks. PR fixes it.

Extension to test (just two empty `package.json` files in both folders). Try from `main` and from this PR branch.
```
yarn cli -e rin-st/test-merge-packages
```

extension repo: https://github.com/rin-st/test-merge-packages

Note: I changed regex from `${sf}$` to `${sf}`. Wondering how first even worked since it requires solidityFramework at the end of the path.