### PR TITLE
Fix .env.example template

### DIFF
--- a/.changeset/famous-keys-drive.md
+++ b/.changeset/famous-keys-drive.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+add possibility to use multiple variables in .env.example

--- a/templates/base/packages/nextjs/.env.example.template.mjs
+++ b/templates/base/packages/nextjs/.env.example.template.mjs
@@ -14,7 +14,7 @@ const contents = ({ additionalVars }) => {
 # More info: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
 NEXT_PUBLIC_ALCHEMY_API_KEY=
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
-${additionalVars.join("\n")}
+${additionalVars[0].join("\n")}
 `
 };
 


### PR DESCRIPTION
Currently, we can't use multiple values since we take stringifyed version even if we pass an array.

For example, if I pass in `.env.example.args.mjs` file

`export const additionalVars = ["SOME_ENV_VAR=", "SOME_ENV_VAR_2="];`

I'm getting this in `.env.example` as a result:
```
...
SOME_ENV_VAR=,SOME_ENV_VAR_2=
```

PR fixes it, so result is

```
...
SOME_ENV_VAR=
SOME_ENV_VAR_2=
```

