### PR TITLE
foundry: remove deploy:verify from base package.json

### DIFF
--- a/.changeset/little-onions-hug.md
+++ b/.changeset/little-onions-hug.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+foundry: remove deploy:verify from base package.json

--- a/templates/solidity-frameworks/foundry/package.json
+++ b/templates/solidity-frameworks/foundry/package.json
@@ -6,7 +6,6 @@
     "chain": "yarn foundry:chain",
     "compile": "yarn foundry:compile",
     "deploy": "yarn foundry:deploy",
-    "deploy:verify": "yarn foundry:deploy-verify",
     "fork": "yarn foundry:fork",
     "format": "yarn next:format && yarn foundry:format",
     "foundry:account": "yarn workspace @se-2/foundry account",


### PR DESCRIPTION
### Description: 

We actually removed `deploy:verify` command from foundry package.json but forgot to remove it from the root. 

