### PR TITLE
initial draft for template args rules

### DIFF
--- a/contributors/TEMPLATING.md
+++ b/contributors/TEMPLATING.md
@@ -240,14 +240,14 @@ export const configOverrides = {
   networks: {
     hardhat: {
       forking: {
-        enabled: '$$$process.env.MAINNET_FORKING_ENABLED === "false"', // enabled: process.env.MAINNET_FORKING_ENABLED === "false"
+        enabled: '$$$process.env.MAINNET_FORKING_ENABLED === "false"', // (expression) enabled: process.env.MAINNET_FORKING_ENABLED === "false"
         blockNumber: 1234567,
       },
     },
     customNetwork: {
       url: "https://custom.network",
-      accounts: ["$$$deployerPrivateKey"], // accounts: [deployerPrivateKey]
-      blah: `test \${CUSTOM_API_KEY}`, // blah: `test ${CUSTOM_API_KEY}`
+      accounts: ["$$$deployerPrivateKey"], // (variable) accounts: [deployerPrivateKey]
+      blah: `test \${CUSTOM_API_KEY}`, // (string interpolation) blah: `test ${CUSTOM_API_KEY}`
       verify: {
         etherscan: {
           apiUrl: "https://api.custom-explorer.io",


### PR DESCRIPTION
### Description: 

The initial draft for initial rules.

I think this should probably be merged after #175. 

After #175 we can update other config files to follow the same patterns like updating `tailwind.config`, `nextjs.config` etc. 



