### PR TITLE
Allow capital letters in extension names

### DIFF
--- a/src/utils/parse-arguments-into-options.ts
+++ b/src/utils/parse-arguments-into-options.ts
@@ -88,7 +88,7 @@ export async function parseArgumentsIntoOptions(
   let project: string | null = args._[0] ?? null;
 
   // use the original extension arg
-  const extensionName = args["--extension"] && rawArgs.slice(2).find(a => a.toLowerCase() === args["--extension"]);
+  const extensionName = args["--extension"];
   // ToDo. Allow multiple
   const extension = extensionName ? await validateExternalExtension(extensionName, dev) : null;
 


### PR DESCRIPTION
Hey guys,

Extensions with capital letters don't work, e.g. `yarn cli -e Uniswap  --dev`

It seems to me that https://github.com/scaffold-eth/create-eth/pull/176/ reintroduced https://github.com/scaffold-eth/create-eth/issues/100 because we don't parse arguments lowercase anymore.

**Note:** 
`externalExtension.toLowerCase()` seems weird [here](https://github.com/scaffold-eth/create-eth/blob/b9614425fdc673968e0a9235dc05d3768eaee2de/src/utils/external-extensions.ts#L19), but I'm not sure what was the original intention, so I didn't change this part.