### PR TITLE
Fix: name as path when initializing 

### DIFF
--- a/.changeset/chatty-mugs-allow.md
+++ b/.changeset/chatty-mugs-allow.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+cli: allow projectName as path while initlializing the cli

--- a/src/utils/prompt-for-missing-options.ts
+++ b/src/utils/prompt-for-missing-options.ts
@@ -2,7 +2,6 @@ import { Options, RawOptions, SolidityFrameworkChoices } from "../types";
 import inquirer from "inquirer";
 import { SOLIDITY_FRAMEWORKS } from "./consts";
 import { validateNpmName } from "./validate-name";
-import { basename, resolve } from "path";
 
 // default values for unspecified args
 const defaultOptions: RawOptions = {
@@ -26,7 +25,7 @@ export async function promptForMissingOptions(
       message: "Your project name:",
       default: defaultOptions.project,
       validate: (name: string) => {
-        const validation = validateNpmName(basename(resolve(name)));
+        const validation = validateNpmName(name);
         if (validation.valid) {
           return true;
         }

--- a/src/utils/validate-name.ts
+++ b/src/utils/validate-name.ts
@@ -1,3 +1,4 @@
+import { basename, resolve } from "path";
 import validateProjectName from "validate-npm-package-name";
 
 type ValidateNpmNameResult =
@@ -10,7 +11,7 @@ type ValidateNpmNameResult =
     };
 
 export function validateNpmName(name: string): ValidateNpmNameResult {
-  const nameValidation = validateProjectName(name);
+  const nameValidation = validateProjectName(basename(resolve(name)));
   if (nameValidation.validForNewPackages) {
     return { valid: true };
   }


### PR DESCRIPTION
added `basename(resolve(...))` as [here](https://github.com/scaffold-eth/create-eth/blob/main/src/utils/prompt-for-missing-options.ts#L29) so validation works only for the last folder in path

fixes #207
