### PR TITLE
up husky version in base package.json

### DIFF
--- a/.changeset/cuddly-rabbits-complain.md
+++ b/.changeset/cuddly-rabbits-complain.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+fix husky pre-commit not woking in insatnce

--- a/.changeset/cuddly-rabbits-complain.md
+++ b/.changeset/cuddly-rabbits-complain.md
@@ -2,4 +2,4 @@
 "create-eth": patch
 ---
 
-fix husky pre-commit not woking in insatnce
+fix husky pre-commit hook not working in generated instance

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -24,7 +24,7 @@
   },
   "packageManager": "yarn@3.2.3",
   "devDependencies": {
-    "husky": "~8.0.3",
+    "husky": "~9.1.6",
     "lint-staged": "~13.2.2"
   },
   "engines": {


### PR DESCRIPTION
### Description: 

I think we forgot to backmerge the husky version update.

In v9 they seem to remove the requirement for [that file being executable](https://github.com/typicode/husky/releases/tag/v9.0.1)

<details>

<summary>
    migration guide: 
</summary>

    
![Screenshot 2025-02-25 at 8 16 06 PM](https://github.com/user-attachments/assets/1175bf95-8a75-400d-beb9-cb6a2d859420)


</details>

Now if create an instance with branch it should work 🙌

### To test: 
1. switch to this branch. 

2. build the package
```ts
yarn build
```

3. run cli: 

```ts
yarn cli -s hardhat
```

you can add this `page.tsx` of created page instance and it should run the precommit hook 

```ts
  let y = 1;
  y = "shiv";
```

