### PR TITLE
move template provider after wagmi

### DIFF
--- a/.changeset/hip-deers-search.md
+++ b/.changeset/hip-deers-search.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+move template provider after wagmi

--- a/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
@@ -58,17 +58,17 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
 
   return (
     <WagmiProvider config={wagmiConfig}>
+    ${providerOpeningTags.join("\n")}
       <QueryClientProvider client={queryClient}>
         <ProgressBar height="3px" color="#2299dd" />
         <RainbowKitProvider
           avatar={BlockieAvatar}
           theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
         >
-          ${providerOpeningTags.join("\n")}
           <ScaffoldEthApp>{children}</ScaffoldEthApp>
-          ${providerClosingTags.join("\n")}
         </RainbowKitProvider>
       </QueryClientProvider>
+    ${providerClosingTags.join("\n")}
     </WagmiProvider>
   );
 };`;


### PR DESCRIPTION
### Description: 

Moves temaplte provider after wagmi provider so that we allow more customization example https://www.rainbowkit.com/docs/authentication#set-up-sign-in-with-ethereum-and-nextauth

Ohh actually subgrpah extension no more requires the provider it was removed in https://github.com/scaffold-eth/create-eth-extensions/pull/43