### PR TITLE
remove `--no-commit` flag for foundry

### DIFF
--- a/.changeset/rude-walls-lie.md
+++ b/.changeset/rude-walls-lie.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+cli: fix foundry nigtly version install command

--- a/src/tasks/create-first-git-commit.ts
+++ b/src/tasks/create-first-git-commit.ts
@@ -13,7 +13,7 @@ export async function createFirstGitCommit(targetDir: string, options: Options) 
     if (options.solidityFramework === SOLIDITY_FRAMEWORKS.FOUNDRY) {
       const foundryWorkSpacePath = path.resolve(targetDir, "packages", SOLIDITY_FRAMEWORKS.FOUNDRY);
       // forge install foundry libraries
-      await execa("forge", ["install", ...foundryLibraries, "--no-commit"], { cwd: foundryWorkSpacePath });
+      await execa("forge", ["install", ...foundryLibraries], { cwd: foundryWorkSpacePath });
       await execa("git", ["add", "-A"], { cwd: targetDir });
       await execa("git", ["commit", "--amend", "--no-edit"], { cwd: targetDir });
     }


### PR DESCRIPTION
### Description: 

In latest foundry nightly version [they removed](https://github.com/foundry-rs/foundry/pull/9884) `--no-commit` flag. So if you were on latest foundry nigtly version you would get: 

<details>

<summary>
    error
</summary>

    
![image](https://github.com/user-attachments/assets/56f1f4c3-de17-477a-9af3-02d2f7c9f783)

</details>

This PR removes the `--no-commit` from forge install. Being compatible with foundry nigtly version and current stable version too (which as `--no-commit` flag)

### Effect of this: 

There won't be any breaking effect of this. 

The only difference will be people using v1-stable or lower version will get this commits on instance scaffolded: 

![Screenshot 2025-02-26 at 6 01 03 PM](https://github.com/user-attachments/assets/e7242ad8-fcaf-4268-aca9-93d0b7398a99)

People who are on nightly and in future when foundry releasees this stable people will get only 1 commit: 

![Screenshot 2025-02-26 at 6 01 17 PM](https://github.com/user-attachments/assets/dd781706-6e9f-4c50-ab54-91501f4feafe)


### To test: 

### Switching to nigtly version: 

Run : 

```
foundryup --install nightly
```

check by `forge --version` <= this should say v1-nigtly

And run `npx create-eth@latest -s foundry` <= this will fail in create-eth latest version. 

But if you switch to this branch and build through cli `yarn build` and then `yarn cli -s foundry` it should work 🙌

### Testing current stable version: 

To get back to stable version: 

```
curl -L https://foundry.paradigm.xyz | bash
```

check by `forge --version` <= this should say v1-stable 