### PR TITLE
Scaffold config new template

### DIFF
--- a/templates/base/packages/nextjs/scaffold.config.ts.template.mjs
+++ b/templates/base/packages/nextjs/scaffold.config.ts.template.mjs
@@ -1,7 +1,41 @@
-import { withDefaults } from '../../../utils.js'
+import { withDefaults, stringify, deepMerge } from "../../../../templates/utils.js";
 
-const contents = ({ chainName }) =>
-`import * as chains from "viem/chains";
+const defaultScaffoldConfig = {
+    // The networks on which your DApp is live
+    targetNetworks: ["$$chains.mainnet$$"],
+
+    // The interval at which your front-end polls the RPC servers for new data
+    // it has no effect if you only target the local network (default is 4000)
+    pollingInterval: 30000,
+  
+    // This is ours Alchemy's default API key.
+    // You can get your own at https://dashboard.alchemyapi.io
+    // It's recommended to store it in an env variable:
+    // .env.local for local testing, and in the Vercel/system env config for live apps.
+    alchemyApiKey: "$$process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || DEFAULT_ALCHEMY_API_KEY$$",
+  
+    // This is ours WalletConnect's default project ID.
+    // You can get your own at https://cloud.walletconnect.com
+    // It's recommended to store it in an env variable:
+    // .env.local for local testing, and in the Vercel/system env config for live apps.
+    walletConnectProjectId: "$$process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || '3a8170812b534d0ff9d794f19a901d64'$$",
+  
+    // Only show the Burner Wallet when running on hardhat network
+    onlyLocalBurnerWallet: true,
+  };
+
+const contents = ({ preConfigContent, configOverrides }) => {
+  // add solidityFramework network
+  const targetNetworks = configOverrides.map(override => override.targetNetworks).flat();
+  const extensionConfigOverrides = configOverrides[configOverrides.length - 1] || {};
+  if (targetNetworks?.length && Object.keys(extensionConfigOverrides).length > 0) {
+    extensionConfigOverrides.targetNetworks = targetNetworks;
+  }
+
+  // Merge the default config with any overrides
+  const finalConfig = deepMerge(defaultScaffoldConfig, extensionConfigOverrides);
+
+  return  `import * as chains from "viem/chains";
 
 export type ScaffoldConfig = {
   targetNetworks: readonly chains.Chain[];
@@ -12,34 +46,15 @@ export type ScaffoldConfig = {
 };
 
 export const DEFAULT_ALCHEMY_API_KEY = "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
+${preConfigContent[0] || ''}
+;
 
-const scaffoldConfig = {
-  // The networks on which your DApp is live
-  targetNetworks: [${chainName.map(chain => `chains.${chain}`).join(', ')}],
+const scaffoldConfig: ScaffoldConfig = ${stringify(finalConfig)};
 
-  // The interval at which your front-end polls the RPC servers for new data
-  // it has no effect if you only target the local network (default is 4000)
-  pollingInterval: 30000,
-
-  // This is ours Alchemy's default API key.
-  // You can get your own at https://dashboard.alchemyapi.io
-  // It's recommended to store it in an env variable:
-  // .env.local for local testing, and in the Vercel/system env config for live apps.
-  alchemyApiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || DEFAULT_ALCHEMY_API_KEY,
-
-  // This is ours WalletConnect's default project ID.
-  // You can get your own at https://cloud.walletconnect.com
-  // It's recommended to store it in an env variable:
-  // .env.local for local testing, and in the Vercel/system env config for live apps.
-  walletConnectProjectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || "3a8170812b534d0ff9d794f19a901d64",
-
-  // Only show the Burner Wallet when running on hardhat network
-  onlyLocalBurnerWallet: true,
-} as const satisfies ScaffoldConfig;
-
-export default scaffoldConfig;
-`
+export default scaffoldConfig;`;
+};
 
 export default withDefaults(contents, {
-  chainName: 'mainnet'
-})
+  preConfigContent: "",
+  configOverrides: {},
+});

--- a/templates/solidity-frameworks/foundry/packages/nextjs/scaffold.config.ts.args.mjs
+++ b/templates/solidity-frameworks/foundry/packages/nextjs/scaffold.config.ts.args.mjs
@@ -1,1 +1,3 @@
-export const chainName = 'foundry'
+export const configOverrides = {
+  targetNetworks: ["$$chains.foundry$$"]
+};

--- a/templates/solidity-frameworks/hardhat/packages/nextjs/scaffold.config.ts.args.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/nextjs/scaffold.config.ts.args.mjs
@@ -1,1 +1,3 @@
-export const chainName = 'hardhat'
+export const configOverrides = {
+  targetNetworks: ["$$chains.hardhat$$"]
+};


### PR DESCRIPTION
to test:

```
yarn cli -e rin-st/scaffold-config-test
```

note: resulting config doesn't have comments like in se-2 or this create-eth template

Result:

```
import * as chains from "viem/chains";

export type ScaffoldConfig = {
  targetNetworks: readonly chains.Chain[];
  pollingInterval: number;
  alchemyApiKey: string;
  walletConnectProjectId: string;
  onlyLocalBurnerWallet: boolean;
};

export const DEFAULT_ALCHEMY_API_KEY = "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";

// Custom variables
const CUSTOM_API_KEY = process.env.CUSTOM_API_KEY;

const scaffoldConfig: ScaffoldConfig = {
  alchemyApiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || DEFAULT_ALCHEMY_API_KEY,
  walletConnectProjectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || "3a8170812b534d0ff9d794f19a901d64",
  targetNetworks: [chains.hardhat, chains.base],
  pollingInterval: 12345,
  onlyLocalBurnerWallet: false,
};

export default scaffoldConfig;
```

extension: https://github.com/rin-st/scaffold-config-test