### PR TITLE
skip relase action version packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Install Dependencies
-        run: yarn
-
       - name: Check for existing release PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,6 +29,10 @@ jobs:
             echo "Release PR already exists."
             echo "SKIP_RELEASE=true" >> $GITHUB_ENV
           fi
+
+      - name: Install Dependencies
+        if: ${{ env.SKIP_RELEASE != 'true' }}
+        run: yarn
 
       - name: Create Release Pull Request or Publish to npm
         if: ${{ env.SKIP_RELEASE != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,18 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
+      - name: Check for existing release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing_pr=$(gh pr list --state open --json title --jq '.[] | select(.title | contains("Version Packages"))')
+          if [ -n "$existing_pr" ]; then
+            echo "Release PR already exists."
+            echo "SKIP_RELEASE=true" >> $GITHUB_ENV
+          fi
+
       - name: Create Release Pull Request or Publish to npm
+        if: ${{ env.SKIP_RELEASE != 'true' }}
         id: changesets
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
### Description: 

Tired it at : 

So I have the Version packages PR already here : https://github.com/technophile-04/test-changeset-flow-package/pull/20 

Now after I merge changes with changes at : https://github.com/technophile-04/test-changeset-flow-package/pull/21 

If you look at github actions on main it skipped the release section (hence not failing the action and showing "x") : 

checkout [this](https://github.com/technophile-04/test-changeset-flow-package/actions/runs/13974845084/job/39125873643) 

<img width="1143" alt="Screenshot 2025-03-20 at 10 21 23 PM" src="https://github.com/user-attachments/assets/534ac05f-9730-4d7d-8c29-dc363dbf6ad4" />


Fixes #204 