### PR TITLE
Create extension from scaffold-eth-2 repo/branch

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,13 +11,13 @@ import { showHelpMessage } from "./utils/show-help-message";
 export async function cli(args: Args) {
   try {
     renderIntroMessage();
-    const { rawOptions, solidityFrameworkChoices } = await parseArgumentsIntoOptions(args);
+    const { rawOptions, solidityFrameworkChoices, fromScaffoldEth } = await parseArgumentsIntoOptions(args);
     if (rawOptions.help) {
       showHelpMessage();
       return;
     }
 
-    const options = await promptForMissingOptions(rawOptions, solidityFrameworkChoices);
+    const options = await promptForMissingOptions(rawOptions, solidityFrameworkChoices, fromScaffoldEth);
     if (options.solidityFramework === SOLIDITY_FRAMEWORKS.FOUNDRY) {
       await validateFoundryUp();
     }

--- a/src/dev/create-extension-common.ts
+++ b/src/dev/create-extension-common.ts
@@ -1,0 +1,11 @@
+import chalk from "chalk";
+
+export const EXTERNAL_EXTENSIONS_DIR = "externalExtensions";
+export const TARGET_EXTENSION_DIR = "extension";
+
+export const prettyLog = {
+  info: (message: string, indent = 0) => console.log(chalk.cyan(`${"  ".repeat(indent)}${message}`)),
+  success: (message: string, indent = 0) => console.log(chalk.green(`${"  ".repeat(indent)}✔︎ ${message}`)),
+  warning: (message: string, indent = 0) => console.log(chalk.yellow(`${"  ".repeat(indent)}⚠ ${message}`)),
+  error: (message: string, indent = 0) => console.log(chalk.red(`${"  ".repeat(indent)}✖ ${message}`)),
+};

--- a/src/dev/create-extension-from-scaffold-eth.ts
+++ b/src/dev/create-extension-from-scaffold-eth.ts
@@ -1,0 +1,235 @@
+import path from "path";
+import fs from "fs";
+import { execa } from "execa";
+import { prettyLog, EXTERNAL_EXTENSIONS_DIR, TARGET_EXTENSION_DIR } from "./create-extension-common";
+import { assertRepoExists, parseExtensionString, setupRepository } from "../utils/common";
+import { SOLIDITY_FRAMEWORKS } from "../utils/consts";
+import { promisify } from "util";
+import ncp from "ncp";
+
+const ncpPromise = promisify(ncp);
+
+export const DELETED_FILES_LOG = "deletedFiles.log";
+export const COMMIT_HASH_LOG = "commitHash.log";
+export const SOLIDITY_FRAMEWORK_LOG = "solidityFramework.log";
+
+export const createExtensionFromScaffoldEth = async (projectName: string, scaffoldEthRepo: string | null) => {
+  try {
+    if (scaffoldEthRepo) {
+      const { githubUrl, githubBranchUrl, branch } = parseExtensionString(scaffoldEthRepo);
+
+      await assertRepoExists(githubBranchUrl, githubUrl);
+
+      prettyLog.info(`Creating ${projectName} folder and cloning ${githubBranchUrl}...`, 1);
+
+      await setupRepository(getProjectDirectory(projectName), githubUrl, branch);
+
+      prettyLog.success(`Cloned ${githubBranchUrl} into ${projectName}\n`, 1);
+    }
+
+    prettyLog.info("Finding merge base commit hash...", 1);
+    const { mergeBaseCommitHash, solidityFramework } = await getMergeBaseCommitHash(projectName);
+    prettyLog.success(`Merge base commit hash: ${mergeBaseCommitHash}\n`, 1);
+
+    prettyLog.info("Getting list of changed files...", 1);
+    const changedFiles = await getChangedFilesSinceCommit(projectName, mergeBaseCommitHash);
+    const deletedAndRenamedFiles = await getDeletedAndRenamedFilesSinceCommit(projectName, mergeBaseCommitHash);
+
+    if (!changedFiles.length && !deletedAndRenamedFiles.length) {
+      prettyLog.warning("No files to process.");
+      return;
+    }
+
+    if (changedFiles.length) {
+      await copyChangedFiles(changedFiles, projectName);
+      prettyLog.success(`Copied ${changedFiles.length} changed files\n`, 1);
+    }
+
+    if (deletedAndRenamedFiles.length) {
+      await logData(projectName, DELETED_FILES_LOG, deletedAndRenamedFiles.join("\n"));
+    }
+
+    await logData(projectName, COMMIT_HASH_LOG, mergeBaseCommitHash);
+
+    await logData(projectName, SOLIDITY_FRAMEWORK_LOG, solidityFramework);
+
+    await initGitRepo(path.join(EXTERNAL_EXTENSIONS_DIR, projectName));
+
+    prettyLog.info(`Files processed successfully, updated ${EXTERNAL_EXTENSIONS_DIR}/${projectName} directory.`);
+  } catch (err: any) {
+    prettyLog.error(`Failed to create extension: ${err.message}`);
+    throw err;
+  } finally {
+    if (scaffoldEthRepo) {
+      await fs.promises.rm(getProjectDirectory(projectName), { recursive: true, force: true });
+      //prettyLog.info(`Cleaned up temporary folder: ${getProjectDirectory(projectName)}\n`, 1);
+    }
+  }
+};
+
+const getMergeBaseCommitHash = async (
+  projectName: string,
+): Promise<{ mergeBaseCommitHash: string; solidityFramework: string }> => {
+  try {
+    // Add the scaffold-eth-2 remote if it doesn’t already exist
+    await execa("git", ["remote", "add", "scaffold-eth-2", "https://github.com/scaffold-eth/scaffold-eth-2"], {
+      cwd: projectName,
+      reject: false,
+    });
+
+    // Fetch only the main and foundry branches from scaffold-eth-2
+    await execa("git", ["fetch", "scaffold-eth-2", "main", "--no-tags"], { cwd: projectName });
+    await execa("git", ["fetch", "scaffold-eth-2", "foundry", "--no-tags"], { cwd: projectName });
+
+    // Get the merge base (common ancestor) between HEAD and scaffold-eth-2/main
+    const { stdout: mainMergeBase } = await execa("git", ["merge-base", "HEAD", "scaffold-eth-2/main"], {
+      cwd: projectName,
+    });
+    // Get the merge base between HEAD and scaffold-eth-2/foundry
+    const { stdout: foundryMergeBase } = await execa("git", ["merge-base", "HEAD", "scaffold-eth-2/foundry"], {
+      cwd: projectName,
+    });
+
+    // If no merge base exists with either branch, throw an error
+    if (!mainMergeBase && !foundryMergeBase) {
+      throw new Error("No merge base found with scaffold-eth-2/main or scaffold-eth-2/foundry");
+    }
+
+    // Get the current HEAD commit hash of scaffold-eth-2/main
+    const { stdout: mainHead } = await execa("git", ["rev-parse", "scaffold-eth-2/main"], { cwd: projectName });
+    // Get the current HEAD commit hash of scaffold-eth-2/foundry
+    const { stdout: foundryHead } = await execa("git", ["rev-parse", "scaffold-eth-2/foundry"], {
+      cwd: projectName,
+    });
+
+    // If the merge base with main equals main’s HEAD (and foundry’s doesn’t), assume main is the origin
+    if (mainMergeBase === mainHead && foundryMergeBase !== foundryHead) {
+      return { mergeBaseCommitHash: mainMergeBase, solidityFramework: SOLIDITY_FRAMEWORKS.HARDHAT };
+    }
+    // If the merge base with foundry equals foundry’s HEAD (and main’s doesn’t), assume foundry is the origin
+    if (foundryMergeBase === foundryHead && mainMergeBase !== mainHead) {
+      return { mergeBaseCommitHash: foundryMergeBase, solidityFramework: SOLIDITY_FRAMEWORKS.FOUNDRY };
+    }
+
+    // If neither merge base matches a HEAD exactly, compare timestamps to determine the more recent ancestor
+    // Get the timestamp (Unix epoch seconds) of the main merge base
+    const { stdout: mainMergeDate } = await execa("git", ["show", "-s", "--format=%ct", mainMergeBase], {
+      cwd: projectName,
+    });
+    // Get the timestamp of the foundry merge base
+    const { stdout: foundryMergeDate } = await execa("git", ["show", "-s", "--format=%ct", foundryMergeBase], {
+      cwd: projectName,
+    });
+
+    // Convert timestamps to integers for comparison
+    const mainTimestamp = parseInt(mainMergeDate, 10);
+    const foundryTimestamp = parseInt(foundryMergeDate, 10);
+
+    // Return the branch with the more recent merge base timestamp
+    if (mainTimestamp > foundryTimestamp) {
+      // Main’s merge base is more recent, so assume it’s the origin
+      return { mergeBaseCommitHash: mainMergeBase, solidityFramework: SOLIDITY_FRAMEWORKS.HARDHAT };
+    } else {
+      // Foundry’s merge base is more recent (or equal), so assume it’s the origin
+      return { mergeBaseCommitHash: foundryMergeBase, solidityFramework: SOLIDITY_FRAMEWORKS.FOUNDRY };
+    }
+  } catch (error: any) {
+    console.error(`Failed to get merge base commit hash: ${error.message}`);
+    throw error;
+  }
+};
+
+const getChangedFilesSinceCommit = async (projectName: string, commitHash: string): Promise<string[]> => {
+  try {
+    const { stdout } = await execa("git", ["diff", "--diff-filter=d", "--name-only", `${commitHash}..HEAD`], {
+      cwd: projectName,
+    });
+
+    return stdout.split("\n").filter(Boolean);
+  } catch (error: any) {
+    console.error(`Failed to get changed files since commit: ${error.message}`);
+    throw error;
+  }
+};
+
+const getDeletedAndRenamedFilesSinceCommit = async (projectName: string, commitHash: string): Promise<string[]> => {
+  try {
+    const { stdout: gitOutput } = await execa(
+      "git",
+      ["diff", "--diff-filter=DR", "--name-status", `${commitHash}..HEAD`],
+      { cwd: projectName },
+    );
+
+    // Process the output to extract deleted and renamed files
+    const deletedAndRenamedFiles = gitOutput
+      .split("\n") // Split into lines
+      .filter(Boolean) // Remove empty lines
+      .map(line => {
+        const parts = line.split("\t");
+        if (line.startsWith("D")) {
+          return parts[1]; // For deleted files, return the file name
+        } else if (line.startsWith("R")) {
+          return parts[1]; // For renamed files, return the original file name
+        }
+        return null; // Ignore other cases
+      })
+      .filter(Boolean); // Remove null entries
+
+    return deletedAndRenamedFiles as string[];
+  } catch (error: any) {
+    console.error(`Failed to get deleted and renamed files: ${error.message}`);
+    throw error;
+  }
+};
+
+const copyChangedFiles = async (changedFiles: string[], projectName: string) => {
+  try {
+    for (const filePath of changedFiles) {
+      const sourcePath = path.resolve(projectName, filePath);
+      const destPath = path.join(EXTERNAL_EXTENSIONS_DIR, projectName, TARGET_EXTENSION_DIR, filePath);
+
+      if (!fs.existsSync(sourcePath)) continue;
+
+      await createDirectory(filePath, projectName);
+      await ncpPromise(sourcePath, destPath);
+    }
+  } catch (error: any) {
+    console.error(`Failed to copy changed files: ${error.message}`);
+    throw error;
+  }
+};
+const createDirectory = async (filePath: string, projectName: string) => {
+  const dirPath = path.join(EXTERNAL_EXTENSIONS_DIR, projectName, TARGET_EXTENSION_DIR, path.dirname(filePath));
+  await fs.promises.mkdir(dirPath, { recursive: true });
+};
+
+const logData = async (projectName: string, fileName: string, fileContent: string) => {
+  try {
+    const logPath = path.join(EXTERNAL_EXTENSIONS_DIR, projectName, TARGET_EXTENSION_DIR, fileName);
+    await fs.promises.writeFile(logPath, fileContent, "utf8");
+    prettyLog.success(`${fileName} logged to ${logPath}\n`, 1);
+  } catch (error: any) {
+    console.error(`Failed to log data to ${fileName}: ${error.message}`);
+    throw error;
+  }
+};
+
+const initGitRepo = async (targetPath: string) => {
+  try {
+    const gitDir = path.join(targetPath, ".git");
+    if (fs.existsSync(gitDir)) {
+      return; // Git repo already exists, likely from a previous run
+    }
+
+    await execa("git", ["init"], { cwd: targetPath });
+    await execa("git", ["add", "."], { cwd: targetPath });
+    await execa("git", ["commit", "-m", "Initial commit"], { cwd: targetPath });
+
+    prettyLog.success(`Initialized git repository and made initial commit in ${targetPath}\n`, 1);
+  } catch (error: any) {
+    console.error(`Failed to initialize git repository: ${error.message}`);
+    throw error;
+  }
+};
+
+const getProjectDirectory = (projectName: string) => path.resolve(process.cwd(), projectName);

--- a/src/from-scaffold-eth.ts
+++ b/src/from-scaffold-eth.ts
@@ -1,0 +1,110 @@
+import { execa } from "execa";
+import type { ExternalExtension, Options } from "./types";
+import path from "path";
+import fs from "fs";
+import { promisify } from "util";
+import ncp from "ncp";
+import { COMMIT_HASH_LOG, DELETED_FILES_LOG, SOLIDITY_FRAMEWORK_LOG } from "./dev/create-extension-from-scaffold-eth";
+import { deleteTempDirectory, setupRepository, EXTERNAL_EXTENSION_TMP_DIR } from "./utils/common";
+import { SOLIDITY_FRAMEWORKS } from "./utils/consts";
+
+// ToDo: Prepare for branch switching, main branch uses hardhat right now, but it can change in the future
+const SCAFFOLD_ETH_2_REPOSITORY_URL = "https://github.com/scaffold-eth/scaffold-eth-2";
+const FOUNDRY_BRANCH = "foundry";
+
+const copy = promisify(ncp);
+
+export const createProjectFromScaffoldEth = async (options: Options, projectName: string) => {
+  await setupRepository(
+    projectName,
+    SCAFFOLD_ETH_2_REPOSITORY_URL,
+    options.solidityFramework === SOLIDITY_FRAMEWORKS.FOUNDRY ? FOUNDRY_BRANCH : null,
+  );
+
+  if (!options.dev) {
+    await setupRepository(
+      getTempDirectory(projectName),
+      (options.externalExtension as ExternalExtension).repository,
+      (options.externalExtension as ExternalExtension).branch,
+    );
+  }
+
+  const externalExtensionPath = getExternalExtensionPath(options, projectName);
+
+  await resetToCommitHash(externalExtensionPath, projectName);
+
+  await copy(externalExtensionPath, projectName, {
+    filter: file => {
+      const relativePath = path.relative(externalExtensionPath, file);
+      return ![COMMIT_HASH_LOG, DELETED_FILES_LOG, SOLIDITY_FRAMEWORK_LOG].includes(relativePath);
+    },
+  });
+
+  await removeLoggedDeletedFiles(externalExtensionPath, projectName);
+
+  await deleteTempDirectory(options, getTempDirectory(projectName));
+
+  await commitChanges(projectName);
+};
+
+const resetToCommitHash = async (externalExtensionPath: string, targetDir: string) => {
+  try {
+    const logPath = path.join(externalExtensionPath, COMMIT_HASH_LOG);
+
+    if (!fs.existsSync(logPath)) {
+      throw new Error(`No commit hash log found at: ${logPath}`);
+    }
+
+    const commitHash = (await fs.promises.readFile(logPath, "utf8")).trim();
+
+    if (!commitHash) {
+      throw new Error("Commit hash log is empty");
+    }
+
+    await execa("git", ["reset", "--hard", commitHash], { cwd: targetDir });
+  } catch (error: any) {
+    console.error(`Failed to reset to commit hash: ${error.message}`);
+    throw error;
+  }
+};
+
+const removeLoggedDeletedFiles = async (externalExtensionPath: string, targetDir: string) => {
+  try {
+    const logPath = path.join(externalExtensionPath, DELETED_FILES_LOG);
+
+    if (fs.existsSync(logPath)) {
+      const deletedFilesContent = await fs.promises.readFile(logPath, "utf8");
+      const deletedFilePaths = deletedFilesContent.split("\n").filter(Boolean);
+
+      for (const deletedFilePath of deletedFilePaths) {
+        const fullPath = path.join(targetDir, deletedFilePath);
+        if (fs.existsSync(fullPath)) {
+          await fs.promises.unlink(fullPath);
+        }
+      }
+    }
+  } catch (error: any) {
+    console.error(`Failed to remove logged deleted files: ${error.message}`);
+    throw error;
+  }
+};
+
+const commitChanges = async (targetDir: string) => {
+  try {
+    await execa("git", ["add", "--all"], { cwd: targetDir });
+    await execa("git", ["commit", "-m", "Apply changes from extension"], { cwd: targetDir });
+  } catch (error: any) {
+    console.error(`Failed to commit changes: ${error.message}`);
+    throw error;
+  }
+};
+
+const getExternalExtensionPath = (options: Options, projectName: string) => {
+  if (options.dev) {
+    return path.join("externalExtensions", options.externalExtension as string, "extension");
+  }
+
+  return path.join(getTempDirectory(projectName), "extension");
+};
+
+const getTempDirectory = (projectName: string) => path.join(projectName, EXTERNAL_EXTENSION_TMP_DIR);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { getArgumentFromExternalExtensionOption } from "./utils/external-extensions";
 import { SOLIDITY_FRAMEWORKS } from "./utils/consts";
+import { createProjectFromScaffoldEth } from "./from-scaffold-eth";
 
 export async function createProject(options: Options) {
   console.log(`\n`);
@@ -33,7 +34,12 @@ export async function createProject(options: Options) {
         title: `🚀 Creating a new Scaffold-ETH 2 app in ${chalk.green.bold(
           options.project,
         )}${options.externalExtension ? ` with the ${chalk.green.bold(options.dev ? options.externalExtension : getArgumentFromExternalExtensionOption(options.externalExtension))} extension` : ""}`,
-        task: () => copyTemplateFiles(options, templateDirectory, targetDirectory),
+        task: () => {
+          if (options.fromScaffoldEth) {
+            return createProjectFromScaffoldEth(options, targetDirectory);
+          }
+          return copyTemplateFiles(options, templateDirectory, targetDirectory);
+        },
       },
       {
         title: "📦 Installing dependencies with yarn, this could take a while",
@@ -56,12 +62,21 @@ export async function createProject(options: Options) {
           if (!options.install) {
             return "Can't use source prettier, since `yarn install` was skipped";
           }
+          if (options.fromScaffoldEth) {
+            return "Skipping prettier format to preserve the original scaffold-eth-2 repository code";
+          }
           return false;
         },
       },
       {
         title: `📡 Initializing Git repository${options.solidityFramework === SOLIDITY_FRAMEWORKS.FOUNDRY ? " and submodules" : ""}`,
         task: () => createFirstGitCommit(targetDirectory, options),
+        skip: () => {
+          if (options.fromScaffoldEth) {
+            return "Extension code was applied and committed on top of the scaffold-eth-2 repository";
+          }
+          return false;
+        },
       },
     ],
     { rendererOptions: { collapseSkips: false, suffixSkips: true } },

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type Options = {
 } & {
   externalExtension: RawOptions["externalExtension"];
   solidityFramework: SolidityFramework | null;
+  fromScaffoldEth: boolean;
 };
 
 export type TemplateDescriptor = {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,91 @@
+import { execa } from "execa";
+import fs from "fs";
+import https from "https";
+import path from "path";
+import { fileURLToPath } from "url";
+import { Options } from "../types";
+
+export const EXTERNAL_EXTENSION_TMP_DIR = "tmp-external-extension";
+
+export const parseExtensionString = (extension: string) => {
+  const isGithubUrl = extension.startsWith("https://github.com/");
+  const regex = /^[^/]+\/[^/]+(:[^/]+)?$/;
+
+  if (!regex.test(extension) && !isGithubUrl) {
+    throw new Error(`Invalid extension format. Use "owner/project", "owner/project:branch" or github url.`);
+  }
+
+  let owner, project, branch;
+
+  if (isGithubUrl) {
+    const { ownerName, repoName, branch: urlBranch } = deconstructGithubUrl(extension);
+    owner = ownerName;
+    project = repoName;
+    branch = urlBranch;
+  } else {
+    owner = extension.split("/")[0];
+    project = extension.split(":")[0].split("/")[1];
+    branch = extension.split(":")[1];
+  }
+
+  const githubUrl = `https://github.com/${owner}/${project}`;
+  const githubBranchUrl = branch ? `https://github.com/${owner}/${project}/tree/${branch}` : githubUrl;
+
+  return {
+    githubUrl,
+    githubBranchUrl,
+    owner,
+    project,
+    branch,
+  };
+};
+
+export function deconstructGithubUrl(url: string) {
+  const urlParts = url.split("/");
+  const ownerName = urlParts[3];
+  const repoName = urlParts[4];
+  const branch = urlParts[5] === "tree" ? urlParts[6] : undefined;
+
+  return { ownerName, repoName, branch };
+}
+
+export async function assertRepoExists(githubBranchUrl: string, githubUrl: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(githubBranchUrl, res => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Extension not found: ${githubUrl}`));
+        } else {
+          resolve();
+        }
+      })
+      .on("error", err => {
+        reject(err);
+      });
+  });
+}
+
+export const setupRepository = async (targetDirectory: string, repository: string, branch?: string | null) => {
+  // 1. Create targetDirectory if needed
+  await fs.promises.mkdir(targetDirectory, { recursive: true });
+
+  // 2. Clone the repository
+  if (branch) {
+    await execa("git", ["clone", "--branch", branch, repository, targetDirectory], {
+      cwd: targetDirectory,
+    });
+  } else {
+    await execa("git", ["clone", repository, targetDirectory], { cwd: targetDirectory });
+  }
+};
+
+export const deleteTempDirectory = async (options: Options, tmpDir: string) => {
+  if (options.externalExtension && !options.dev) {
+    await fs.promises.rm(tmpDir, { recursive: true });
+  }
+};
+
+export const getExternalExtensionsDirectory = (): string => {
+  const currentFileUrl = import.meta.url;
+  return path.resolve(decodeURI(fileURLToPath(currentFileUrl)), "../../externalExtensions");
+};

--- a/src/utils/prompt-for-missing-options.ts
+++ b/src/utils/prompt-for-missing-options.ts
@@ -16,6 +16,7 @@ const defaultOptions: RawOptions = {
 export async function promptForMissingOptions(
   options: RawOptions,
   solidityFrameworkChoices: SolidityFrameworkChoices,
+  fromScaffoldEth: boolean,
 ): Promise<Options> {
   const cliAnswers = Object.fromEntries(Object.entries(options).filter(([, value]) => value !== null));
   const questions = [
@@ -50,6 +51,7 @@ export async function promptForMissingOptions(
     dev: options.dev ?? defaultOptions.dev,
     solidityFramework: solidityFramework === "none" ? null : solidityFramework,
     externalExtension: options.externalExtension,
+    fromScaffoldEth,
   };
 
   return mergedOptions;


### PR DESCRIPTION
Hey guys,

This PR introduces a new option to create extensions, here is how I tested it

`yarn build:dev`

**Test Cases:**

- Create extension from https://github.com/kmjones1979/scaffold-eth-agent-the-graph
`yarn create-extension extension-scaffold-eth-agent-the-graph --from-scaffold-eth https://github.com/kmjones1979/scaffold-eth-agent-the-graph`
-> creates extension at externalExtensions/extension-scaffold-eth-agent-the-graph, github: moltam89/extension-scaffold-eth-agent-the-graph
`yarn cli -e moltam89/extension-scaffold-eth-agent-the-graph`
-> creates the project
- Create extension from https://github.com/moltam89/scaffold-eth-2/tree/UniswapX
`yarn create-extension extension-uniswapx -f https://github.com/moltam89/scaffold-eth-2/tree/UniswapX`
-> creates extension-uniswapx, github: moltam89/extension-uniswapx
`yarn cli -e moltam89/extension-uniswapx`
-> creates the project
- Create extension from Foundry
`yarn cli -e moltam89/extension-foundry`

cc @technophile-04 @kmjones1979

Cheers,
Tamas
