### PR TITLE
(beta) fix fastify/deepMerge not found

### DIFF
--- a/.changeset/cold-rings-sing.md
+++ b/.changeset/cold-rings-sing.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+move fastify/deepmerge to main dependency

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.15.0",
-    "@fastify/deepmerge": "^2.0.1",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "11.1.0",
     "@types/inquirer": "9.0.3",
@@ -54,6 +53,7 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.26.2",
+    "@fastify/deepmerge": "^2.0.1",
     "arg": "5.0.2",
     "chalk": "5.2.0",
     "execa": "7.1.1",


### PR DESCRIPTION
### Description: 

Actually we had in devDependency but since we want this to be ran while creating instance moved it to main dependency 