### PR TITLE
(beta) more upate to template files

### DIFF
--- a/.changeset/nervous-cheetahs-deny.md
+++ b/.changeset/nervous-cheetahs-deny.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+rename args from ${somethingImports} => ${preConfigContent} in templates files

--- a/contributors/TEMPLATING.md
+++ b/contributors/TEMPLATING.md
@@ -184,7 +184,7 @@ This customisation can be broadly broken into:
 1. **When extending/modifying already declared variables/objects**:
 
 - Use `preConfigContent` (string) for imports and variable declarations
-- Use `<name>Override` (object) to extend existing variables/objects
+- Use `<name>Overrides` (object) to extend existing variables/objects
 - Can reference variables defined in template and `preConfigContent` in two ways:
   - `$$variableName$$` - When variable needs to be used without quotes (expressions/variables)
     - example: `{ accounts: ["$$deployerPrivateKey$$"] }` -> `{ accounts: [deployerPrivateKey] }`
@@ -276,7 +276,7 @@ export const configOverrides = {
 export default withDefaults(
   ({ preConfigContent, renderContent }) => `
 import { Base } from './Base';
-${preConfigContent}
+${preConfigContent[0] || ""}
 
 export const Component = () => {
 ${renderContent}

--- a/templates/base/packages/nextjs/app/layout.tsx.template.mjs
+++ b/templates/base/packages/nextjs/app/layout.tsx.template.mjs
@@ -1,6 +1,13 @@
-import { withDefaults } from "../../../../utils.js";
+import { deepMerge, stringify, withDefaults } from "../../../../utils.js";
 
-const contents = ({ imports, metadata }) => {
+const defaultMetadata = {
+  title: "Scaffold-ETH 2 App",
+  description: "Built with 🏗 Scaffold-ETH 2"
+}
+
+const contents = ({ imports, metadataOverrides }) => {
+  const finalMetadata = deepMerge(defaultMetadata, metadataOverrides[0] || {});
+
   return `
 ${imports.filter(Boolean).join("\n")}
 import "@rainbow-me/rainbowkit/styles.css";
@@ -9,7 +16,7 @@ import { ThemeProvider } from "~~/components/ThemeProvider";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
-export const metadata = getMetadata(${JSON.stringify(metadata[0])});
+export const metadata = getMetadata(${stringify(finalMetadata)});
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -28,8 +35,5 @@ export default ScaffoldEthApp;`;
 
 export default withDefaults(contents, {
   imports: "",
-  metadata: {
-    title: "Scaffold-ETH 2 App",
-    description: "Built with 🏗 Scaffold-ETH 2"
-  }
+  metadataOverrides: ""
 });

--- a/templates/base/packages/nextjs/app/layout.tsx.template.mjs
+++ b/templates/base/packages/nextjs/app/layout.tsx.template.mjs
@@ -14,7 +14,7 @@ import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithPro
 import { ThemeProvider } from "~~/components/ThemeProvider";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
-${preConfigContent.filter(Boolean).join("\n")}
+${preConfigContent[0] || ''}
 
 export const metadata = getMetadata(${stringify(finalMetadata)});
 

--- a/templates/base/packages/nextjs/app/layout.tsx.template.mjs
+++ b/templates/base/packages/nextjs/app/layout.tsx.template.mjs
@@ -5,16 +5,16 @@ const defaultMetadata = {
   description: "Built with 🏗 Scaffold-ETH 2"
 }
 
-const contents = ({ imports, metadataOverrides }) => {
+const contents = ({ preConfigContent, metadataOverrides }) => {
   const finalMetadata = deepMerge(defaultMetadata, metadataOverrides[0] || {});
 
   return `
-${imports.filter(Boolean).join("\n")}
 import "@rainbow-me/rainbowkit/styles.css";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+${preConfigContent.filter(Boolean).join("\n")}
 
 export const metadata = getMetadata(${stringify(finalMetadata)});
 
@@ -34,6 +34,6 @@ export default ScaffoldEthApp;`;
 };
 
 export default withDefaults(contents, {
-  imports: "",
+  preConfigContent: "",
   metadataOverrides: ""
 });

--- a/templates/base/packages/nextjs/app/page.tsx.template.mjs
+++ b/templates/base/packages/nextjs/app/page.tsx.template.mjs
@@ -13,7 +13,7 @@ import { Address } from "~~/components/scaffold-eth";
 import type { NextPage } from "next";
 import Link from "next/link";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
-${preConfigContent}
+${preConfigContent[0] || ''}
 
 const Home: NextPage = () => {
   const { address: connectedAddress } = useAccount();

--- a/templates/base/packages/nextjs/app/page.tsx.template.mjs
+++ b/templates/base/packages/nextjs/app/page.tsx.template.mjs
@@ -1,6 +1,6 @@
 import { withDefaults } from "../../../../utils.js";
 
-const contents = ({ imports, externalExtensionName, description, fullContentOverride }) => {
+const contents = ({ preConfigContent, externalExtensionName, description, fullContentOverride }) => {
   if (fullContentOverride[0]) {
     return fullContentOverride[0];
   }
@@ -13,7 +13,7 @@ import { Address } from "~~/components/scaffold-eth";
 import type { NextPage } from "next";
 import Link from "next/link";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
-${imports}
+${preConfigContent}
 
 const Home: NextPage = () => {
   const { address: connectedAddress } = useAccount();
@@ -68,7 +68,7 @@ export default Home;
 };
 
 export default withDefaults(contents, {
-  imports: ``,
+  preConfigContent: ``,
   description: `
 <p className="text-center text-lg">
   Get started by editing{" "}

--- a/templates/base/packages/nextjs/components/Header.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/Header.tsx.template.mjs
@@ -26,7 +26,8 @@ import { hardhat } from "viem/chains";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick, useTargetNetwork } from "~~/hooks/scaffold-eth";
-${preConfigContent.filter(Boolean).join("\n")}
+${preConfigContent[0] || ''}
+
 
 type HeaderMenuLink = {
   label: string;

--- a/templates/base/packages/nextjs/components/Header.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/Header.tsx.template.mjs
@@ -1,6 +1,20 @@
-import { withDefaults } from "../../../../utils.js";
-const contents = ({ menuIconImports, menuObjects, logoTitle, logoSubtitle }) => {
-  const stringifiedAdditionalMenuLinks = menuObjects.filter(Boolean).join(",\n");
+import { withDefaults, stringify, deepMerge } from "../../../../utils.js";
+
+const defaultMenuLinks = [
+  {
+    label: "Home",
+    href: "/",
+  },
+  {
+    label: "Debug Contracts",
+    href: "/debug",
+    icon: '$$<BugAntIcon className="h-4 w-4" />$$',
+  },
+];
+
+const contents = ({ menuIconImports, extraMenuLinksObjects, logoTitle, logoSubtitle }) => {
+  // make sure debug contracts is the last item
+  const menuLinks = deepMerge([defaultMenuLinks[0]], [...(extraMenuLinksObjects[0] || []), defaultMenuLinks[1]]);
 
   return `"use client";
 
@@ -20,18 +34,7 @@ type HeaderMenuLink = {
   icon?: React.ReactNode;
 };
 
-export const menuLinks: HeaderMenuLink[] = [
-  {
-    label: "Home",
-    href: "/",
-  },
-  ${stringifiedAdditionalMenuLinks && `${stringifiedAdditionalMenuLinks},`}
-  {
-    label: "Debug Contracts",
-    href: "/debug",
-    icon: <BugAntIcon className="h-4 w-4" />,
-  },
-];
+export const menuLinks: HeaderMenuLink[] = ${stringify(menuLinks)};
 
 export const HeaderMenuLinks = () => {
   const pathname = usePathname();
@@ -122,7 +125,7 @@ export const Header = () => {
 
 export default withDefaults(contents, {
   menuIconImports: "",
-  menuObjects: "",
+  extraMenuLinksObjects: "",
   logoTitle: "Scaffold-ETH",
   logoSubtitle: "Ethereum dev stack"
 });

--- a/templates/base/packages/nextjs/components/Header.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/Header.tsx.template.mjs
@@ -12,7 +12,7 @@ const defaultMenuLinks = [
   },
 ];
 
-const contents = ({ menuIconImports, extraMenuLinksObjects, logoTitle, logoSubtitle }) => {
+const contents = ({ preContent, extraMenuLinksObjects, logoTitle, logoSubtitle }) => {
   // make sure debug contracts is the last item
   const menuLinks = deepMerge([defaultMenuLinks[0]], [...(extraMenuLinksObjects[0] || []), defaultMenuLinks[1]]);
 
@@ -26,7 +26,7 @@ import { hardhat } from "viem/chains";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick, useTargetNetwork } from "~~/hooks/scaffold-eth";
-${menuIconImports.filter(Boolean).join("\n")}
+${preContent.filter(Boolean).join("\n")}
 
 type HeaderMenuLink = {
   label: string;
@@ -124,7 +124,7 @@ export const Header = () => {
 };
 
 export default withDefaults(contents, {
-  menuIconImports: "",
+  preContent: "",
   extraMenuLinksObjects: "",
   logoTitle: "Scaffold-ETH",
   logoSubtitle: "Ethereum dev stack"

--- a/templates/base/packages/nextjs/components/Header.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/Header.tsx.template.mjs
@@ -12,7 +12,7 @@ const defaultMenuLinks = [
   },
 ];
 
-const contents = ({ preContent, extraMenuLinksObjects, logoTitle, logoSubtitle }) => {
+const contents = ({ preConfigContent, extraMenuLinksObjects, logoTitle, logoSubtitle }) => {
   // make sure debug contracts is the last item
   const menuLinks = deepMerge([defaultMenuLinks[0]], [...(extraMenuLinksObjects[0] || []), defaultMenuLinks[1]]);
 
@@ -26,7 +26,7 @@ import { hardhat } from "viem/chains";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick, useTargetNetwork } from "~~/hooks/scaffold-eth";
-${preContent.filter(Boolean).join("\n")}
+${preConfigContent.filter(Boolean).join("\n")}
 
 type HeaderMenuLink = {
   label: string;
@@ -124,7 +124,7 @@ export const Header = () => {
 };
 
 export default withDefaults(contents, {
-  preContent: "",
+  preConfigContent: "",
   extraMenuLinksObjects: "",
   logoTitle: "Scaffold-ETH",
   logoSubtitle: "Ethereum dev stack"

--- a/templates/base/packages/nextjs/components/Header.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/Header.tsx.template.mjs
@@ -14,7 +14,7 @@ const defaultMenuLinks = [
 
 const contents = ({ preConfigContent, extraMenuLinksObjects, logoTitle, logoSubtitle }) => {
   // make sure debug contracts is the last item
-  const menuLinks = deepMerge([defaultMenuLinks[0]], [...(extraMenuLinksObjects[0] || []), defaultMenuLinks[1]]);
+  const menuLinks = [defaultMenuLinks[0], ...(extraMenuLinksObjects[0] || []), defaultMenuLinks[1]];
 
   return `"use client";
 

--- a/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
@@ -20,7 +20,7 @@ import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
-${preConfigContent.filter(Boolean).join("\n")}
+${preConfigContent[0] || ''}
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   useInitializeNativeCurrencyPrice();

--- a/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
@@ -1,6 +1,6 @@
 import { withDefaults } from "../../../../utils.js";
 
-const contents = ({ providerNames, providerSetups, providerImports, providerProps, globalClassNames }) => {
+const contents = ({ providerNames, preContent, providerProps, globalClassNames }) => {
   // filter out empty strings
   const providerOpeningTags = providerNames.filter(Boolean).map((name, index) => `<${name} ${providerProps[index]}>`);
 
@@ -20,7 +20,7 @@ import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
-${providerImports.filter(Boolean).join("\n")}
+${preContent.filter(Boolean).join("\n")}
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   useInitializeNativeCurrencyPrice();
@@ -44,8 +44,6 @@ export const queryClient = new QueryClient({
     },
   },
 });
-
-${providerSetups.filter(Boolean).join("\n")}
 
 export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }) => {
   const { resolvedTheme } = useTheme();
@@ -76,8 +74,7 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
 
 export default withDefaults(contents, {
   providerNames: "",
-  providerSetups: "",
-  providerImports: "",
+  preContent: "",
   providerProps: "",
   globalClassNames: "",
 });

--- a/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
+++ b/templates/base/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.template.mjs
@@ -1,6 +1,6 @@
 import { withDefaults } from "../../../../utils.js";
 
-const contents = ({ providerNames, preContent, providerProps, globalClassNames }) => {
+const contents = ({ providerNames, preConfigContent, providerProps, globalClassNames }) => {
   // filter out empty strings
   const providerOpeningTags = providerNames.filter(Boolean).map((name, index) => `<${name} ${providerProps[index]}>`);
 
@@ -20,7 +20,7 @@ import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
-${preContent.filter(Boolean).join("\n")}
+${preConfigContent.filter(Boolean).join("\n")}
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   useInitializeNativeCurrencyPrice();
@@ -74,7 +74,7 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
 
 export default withDefaults(contents, {
   providerNames: "",
-  preContent: "",
+  preConfigContent: "",
   providerProps: "",
   globalClassNames: "",
 });

--- a/templates/base/packages/nextjs/contracts/externalContracts.ts.template.mjs
+++ b/templates/base/packages/nextjs/contracts/externalContracts.ts.template.mjs
@@ -1,4 +1,4 @@
-import { withDefaults } from '../../../../utils.js'
+import { stringify, withDefaults } from '../../../../utils.js'
 
 const contents = ({ externalContracts }) =>
 `import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
@@ -14,7 +14,7 @@ const contents = ({ externalContracts }) =>
  *   },
  * } as const;
  */
-const externalContracts = ${JSON.stringify(externalContracts[0])} as const;
+const externalContracts = ${stringify(externalContracts[0])} as const;
 
 export default externalContracts satisfies GenericContractsDeclaration;
 `

--- a/templates/base/packages/nextjs/styles/globals.css.template.mjs
+++ b/templates/base/packages/nextjs/styles/globals.css.template.mjs
@@ -1,7 +1,7 @@
 import { withDefaults } from '../../../../utils.js'
 
-const contents = ({ preConfigContents }) =>
-`${preConfigContents}
+const contents = ({ preConfigContent }) =>
+`${preConfigContent}
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
@@ -37,5 +37,5 @@ p {
 `
 
 export default withDefaults(contents, {
-  preConfigContents: ''
+  preConfigContent: ''
 })

--- a/templates/base/packages/nextjs/styles/globals.css.template.mjs
+++ b/templates/base/packages/nextjs/styles/globals.css.template.mjs
@@ -1,7 +1,7 @@
 import { withDefaults } from '../../../../utils.js'
 
-const contents = ({ globalImports }) =>
-`${globalImports}
+const contents = ({ preConfigContents }) =>
+`${preConfigContents}
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
@@ -37,5 +37,5 @@ p {
 `
 
 export default withDefaults(contents, {
-  globalImports: ''
+  preConfigContents: ''
 })

--- a/templates/base/packages/nextjs/utils/scaffold-eth/getMetadata.ts.template.mjs
+++ b/templates/base/packages/nextjs/utils/scaffold-eth/getMetadata.ts.template.mjs
@@ -1,7 +1,45 @@
-import { withDefaults } from '../../../../../utils.js'
+import { deepMerge, stringify, withDefaults } from '../../../../../utils.js'
 
-const contents = ({ titleTemplate, extraIcons, extraMetadata, thumbnailPath }) => `
+const defaultMetadata = {
+  metadataBase: '$$new URL(baseUrl)$$',
+  title: {
+    default: '$$title$$',
+    template: '$$titleTemplate$$',
+  },
+  description: '$$description$$',
+  openGraph: {
+    title: {
+      default: '$$title$$',
+      template: '$$titleTemplate$$',
+    },
+    description: '$$description$$',
+    images: [
+      {
+        url: '$$imageUrl$$',
+      },
+    ],
+  },
+  twitter: {
+    title: {
+      default: '$$title$$',
+      template: '$$titleTemplate$$',
+    },
+    description: '$$description$$',
+    images: ['$$imageUrl$$'],
+  },
+  icons: {
+    icon: [{ url: "/favicon.png", sizes: "32x32", type: "image/png" }],
+  },
+}
+
+
+const contents = ({ titleTemplate, thumbnailPath, preConfigContent, metadataOverrides }) =>  {
+  
+  const finalMetadata = deepMerge(defaultMetadata, metadataOverrides[0] || {})
+  
+  return `
 import type { Metadata } from "next";
+${preConfigContent[0] || ''}
 
 const baseUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? \`https://\${process.env.VERCEL_PROJECT_PRODUCTION_URL}\`
@@ -19,45 +57,13 @@ export const getMetadata = ({
 }): Metadata => {
   const imageUrl = \`\${baseUrl}\${imageRelativePath}\`;
 
-  return {
-    metadataBase: new URL(baseUrl),
-    title: {
-      default: title,
-      template: titleTemplate,
-    },
-    description: description,
-    openGraph: {
-      title: {
-        default: title,
-        template: titleTemplate,
-      },
-      description: description,
-      images: [
-        {
-          url: imageUrl,
-        },
-      ],
-    },
-    twitter: {
-      title: {
-        default: title,
-        template: titleTemplate,
-      },
-      description: description,
-      images: [imageUrl],
-    },
-    icons: {
-      icon: [{ url: "/favicon.png", sizes: "32x32", type: "image/png" }],
-      ${extraIcons[0] ? Object.entries(extraIcons[0]).map(([key, value]) => `${key}: ${JSON.stringify(value)}`).join(',\n      ') : ''}
-    },
-    ${extraMetadata[0] ? Object.entries(extraMetadata[0]).map(([key, value]) => `${key}: ${JSON.stringify(value)}`).join(',\n    ') : ''}
-  };
-};
-`
+  return ${stringify(finalMetadata)};
+}`
+}
 
 export default withDefaults(contents, {
-  extraIcons: {},
-  extraMetadata: {},
+  metadataOverrides: {},
   titleTemplate: "%s | Scaffold-ETH 2",
   thumbnailPath: "/thumbnail.jpg",
+  preConfigContent: '',
 })

--- a/templates/example-contracts/foundry/packages/foundry/script/Deploy.s.sol.args.mjs
+++ b/templates/example-contracts/foundry/packages/foundry/script/Deploy.s.sol.args.mjs
@@ -1,4 +1,4 @@
-export const deploymentsScriptsImports = `import { DeployYourContract } from "./DeployYourContract.s.sol";`;
+export const preConfigContent = `import { DeployYourContract } from "./DeployYourContract.s.sol";`;
 export const deploymentsLogic = `
     DeployYourContract deployYourContract = new DeployYourContract();
     deployYourContract.run();

--- a/templates/solidity-frameworks/foundry/packages/foundry/script/Deploy.s.sol.template.mjs
+++ b/templates/solidity-frameworks/foundry/packages/foundry/script/Deploy.s.sol.template.mjs
@@ -4,7 +4,7 @@ const content = ({ preConfigContent, deploymentsLogic }) => `//SPDX-License-Iden
 pragma solidity ^0.8.19;
 
 import "./DeployHelpers.s.sol";
-${preConfigContent.filter(Boolean).join("\n")}
+${preConfigContent[0] || ''}
 
 /**
  * @notice Main deployment script for all contracts

--- a/templates/solidity-frameworks/foundry/packages/foundry/script/Deploy.s.sol.template.mjs
+++ b/templates/solidity-frameworks/foundry/packages/foundry/script/Deploy.s.sol.template.mjs
@@ -1,10 +1,10 @@
 import { withDefaults } from "../../../../../utils.js";
 
-const content = ({ deploymentsScriptsImports, deploymentsLogic }) => `//SPDX-License-Identifier: MIT
+const content = ({ preConfigContent, deploymentsLogic }) => `//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 import "./DeployHelpers.s.sol";
-${deploymentsScriptsImports.filter(Boolean).join("\n")}
+${preConfigContent.filter(Boolean).join("\n")}
 
 /**
  * @notice Main deployment script for all contracts
@@ -26,7 +26,7 @@ contract DeployScript is ScaffoldETHDeploy {
 }`;
 
 export default withDefaults(content, {
-  deploymentsScriptsImports: `import { DeployYourContract } from "./DeployYourContract.s.sol";`,
+  preConfigContent: `import { DeployYourContract } from "./DeployYourContract.s.sol";`,
   deploymentsLogic: `
     DeployYourContract deployYourContract = new DeployYourContract();
     deployYourContract.run();

--- a/templates/utils.js
+++ b/templates/utils.js
@@ -10,13 +10,8 @@ const replaceByClonedSource = options => {
 };
 
 const deepMergeWithoutKeysOrder = createDeepMerge({ mergeArray: replaceByClonedSource });
-const deepMergeArray = createDeepMerge();
 
 export const deepMerge = (...args) => {
-  if (Array.isArray(args[0])) {
-    // For arrays, use deepMergeArray which concatenates array elements
-    return deepMergeArray(...args);
-  }
   const mergedConfig = deepMergeWithoutKeysOrder(...args);
   const finalConfig = {};
   for (const key of Object.keys(args[0])) {

--- a/templates/utils.js
+++ b/templates/utils.js
@@ -10,8 +10,12 @@ const replaceByClonedSource = options => {
 };
 
 const deepMergeWithoutKeysOrder = createDeepMerge({ mergeArray: replaceByClonedSource });
+const deepMergeArray = createDeepMerge();
 
 export const deepMerge = (...args) => {
+  if (Array.isArray(args[0])) {
+    return deepMergeArray(...args);
+  }
   const mergedConfig = deepMergeWithoutKeysOrder(...args);
   const finalConfig = {};
   for (const key of Object.keys(args[0])) {

--- a/templates/utils.js
+++ b/templates/utils.js
@@ -14,6 +14,7 @@ const deepMergeArray = createDeepMerge();
 
 export const deepMerge = (...args) => {
   if (Array.isArray(args[0])) {
+    // For arrays, use deepMergeArray which concatenates array elements
     return deepMergeArray(...args);
   }
   const mergedConfig = deepMergeWithoutKeysOrder(...args);


### PR DESCRIPTION
### Description: 

Update the `template.mjs` files to folllow rules which we mentioned in : 

https://github.com/scaffold-eth/create-eth/blob/beta/contributors/TEMPLATING.md#rules-for-template-args

Mainly it consist renaming of `${somethingImports}` => `${preConfigContent}` so the user know's that this arg variable is not just only for adding imports but also they can add new variables / logic their too along with imports

To test: 

```shell
yarn build:dev && yarn cli -e https://github.com/scaffold-eth/create-eth-extensions/tree/example-beta-extra-templates
```

--- 

In other PR I will update `ScaffoldEthProvider` more customizable and also `Header.tsx` so that people can replace Rainbowkit with some custom wallet etc(like dynamic or etc extensions). I think we will need to use [builderProvidersTree](https://www.google.com/search?q=buildProvidersTree+react+proivder+hell) but we can discuss in other PR 🙌