### PR TITLE
fix: remove outdated dep

### DIFF
--- a/.changeset/dry-readers-fry.md
+++ b/.changeset/dry-readers-fry.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+fix: remove outdated typescript-eslint/eslint-plugin

--- a/templates/base/packages/nextjs/package.json
+++ b/templates/base/packages/nextjs/package.json
@@ -42,7 +42,6 @@
     "@trivago/prettier-plugin-sort-imports": "~4.3.0",
     "@types/node": "~18.19.50",
     "@types/react": "~19.0.7",
-    "@typescript-eslint/eslint-plugin": "~5.40.0",
     "abitype": "1.0.6",
     "autoprefixer": "~10.4.20",
     "bgipfs": "~0.0.12",


### PR DESCRIPTION
for some reason we still have `"@typescript-eslint/eslint-plugin": "~5.40.0",` package which was removed from se-2 long time ago.

https://github.com/scaffold-eth/scaffold-eth-2/pull/963/files#diff-e5237f683dda3354b835c7c7c94b9759db2c743d4ba94d47d7f8b8e0b2bfb442L42

And now it started to break linting. Removed this package and everything seems to work.

Also, current version of that package is included in `eslint-config-next`

<img width="967" alt="image" src="https://github.com/user-attachments/assets/58f33650-f36d-4602-92aa-5370cc381998" />

Looks like they broke `^5.4.2` part

Fixes https://github.com/scaffold-eth/scaffold-eth-2/issues/1085