### PR TITLE
Requirements check when doing npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "listr2": "^8.2.1",
     "merge-packages": "^0.1.6",
     "ncp": "2.0.0",
+    "semver": "^7.7.2",
     "validate-npm-package-name": "6.0.0"
   },
   "packageManager": "yarn@3.5.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,12 +5,21 @@ import { renderIntroMessage } from "./utils/render-intro-message";
 import type { Args } from "./types";
 import chalk from "chalk";
 import { SOLIDITY_FRAMEWORKS } from "./utils/consts";
-import { validateFoundryUp } from "./utils/system-validation";
+import { validateFoundryUp, checkSystemRequirements } from "./utils/system-validation";
 import { showHelpMessage } from "./utils/show-help-message";
 
 export async function cli(args: Args) {
   try {
     renderIntroMessage();
+
+    const { errors } = await checkSystemRequirements();
+
+    if (errors.length > 0) {
+      console.log(chalk.red("\n❌ Create-eth requirements not met:"));
+      errors.forEach(error => console.log(chalk.red(`  - ${error}`)));
+      process.exit(1);
+    }
+
     const { rawOptions, solidityFrameworkChoices } = await parseArgumentsIntoOptions(args);
     if (rawOptions.help) {
       showHelpMessage();

--- a/src/utils/system-validation.ts
+++ b/src/utils/system-validation.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { execa } from "execa";
+import semver from "semver";
 
 export const validateFoundryUp = async () => {
   try {
@@ -11,4 +12,44 @@ export const validateFoundryUp = async () => {
     `;
     throw new Error(message);
   }
+};
+
+export const checkSystemRequirements = async () => {
+  const errors: string[] = [];
+
+  try {
+    const { stdout: nodeVersion } = await execa("node", ["--version"]);
+    const cleanNodeVersion = nodeVersion.replace("v", "");
+    if (!semver.gte(cleanNodeVersion, "20.18.3")) {
+      errors.push(`Node.js version must be >= 20.18.3. Current version: ${nodeVersion}`);
+    }
+  } catch {
+    errors.push("Node.js is not installed. Please install Node.js >= 20.18.3");
+  }
+
+  try {
+    const { stdout: yarnVersion } = await execa("yarn", ["--version"]);
+    if (!semver.gte(yarnVersion, "1.0.0")) {
+      errors.push(`Yarn version should be >= 1.0.0. Recommended version is >= 2.0.0. Current version: ${yarnVersion}`);
+    }
+  } catch {
+    errors.push("Yarn is not installed. Please install Yarn >= 1.0.0. Recommended version is >= 2.0.0");
+  }
+
+  try {
+    const { stdout: gitVersion } = await execa("git", ["--version"]);
+    // Handle both Windows and Unix-style Git version outputs
+    // Windows: git version 2.39.2.windows.1
+    // Unix: git version 2.39.2
+    const versionMatch = gitVersion.match(/(\d+\.\d+\.\d+)/);
+    const cleanGitVersion = versionMatch ? versionMatch[1] : null;
+
+    if (cleanGitVersion && !semver.gte(cleanGitVersion, "2.20.0")) {
+      errors.push(`Git version should be >= 2.20.0 for modern features. Current version: ${gitVersion}`);
+    }
+  } catch {
+    errors.push("Git is not installed. Please install Git >= 2.20.0");
+  }
+
+  return { errors };
 };

--- a/src/utils/system-validation.ts
+++ b/src/utils/system-validation.ts
@@ -20,7 +20,7 @@ export const checkSystemRequirements = async () => {
   try {
     const { stdout: nodeVersion } = await execa("node", ["--version"]);
     const cleanNodeVersion = nodeVersion.replace("v", "");
-    if (!semver.gte(cleanNodeVersion, "20.18.3")) {
+    if (semver.lt(cleanNodeVersion, "20.18.3")) {
       errors.push(`Node.js version must be >= 20.18.3. Current version: ${nodeVersion}`);
     }
   } catch {
@@ -29,7 +29,7 @@ export const checkSystemRequirements = async () => {
 
   try {
     const { stdout: yarnVersion } = await execa("yarn", ["--version"]);
-    if (!semver.gte(yarnVersion, "1.0.0")) {
+    if (semver.lt(yarnVersion, "1.0.0")) {
       errors.push(`Yarn version should be >= 1.0.0. Recommended version is >= 2.0.0. Current version: ${yarnVersion}`);
     }
   } catch {
@@ -44,7 +44,7 @@ export const checkSystemRequirements = async () => {
     const versionMatch = gitVersion.match(/(\d+\.\d+\.\d+)/);
     const cleanGitVersion = versionMatch ? versionMatch[1] : null;
 
-    if (cleanGitVersion && !semver.gte(cleanGitVersion, "2.20.0")) {
+    if (cleanGitVersion && semver.lt(cleanGitVersion, "2.20.0")) {
       errors.push(`Git version should be >= 2.20.0 for modern features. Current version: ${gitVersion}`);
     }
   } catch {

--- a/src/utils/system-validation.ts
+++ b/src/utils/system-validation.ts
@@ -38,6 +38,20 @@ export const checkSystemRequirements = async () => {
 
   try {
     await execa("git", ["--version"]);
+
+    try {
+      await execa("git", ["config", "user.name"]);
+    } catch {
+      errors.push("Git user.name is not configured. Please set it using: git config --global user.name 'Your Name'");
+    }
+
+    try {
+      await execa("git", ["config", "user.email"]);
+    } catch {
+      errors.push(
+        "Git user.email is not configured. Please set it using: git config --global user.email 'your.email@example.com'",
+      );
+    }
   } catch {
     errors.push("Git is not installed. Please install Git");
   }

--- a/src/utils/system-validation.ts
+++ b/src/utils/system-validation.ts
@@ -37,18 +37,9 @@ export const checkSystemRequirements = async () => {
   }
 
   try {
-    const { stdout: gitVersion } = await execa("git", ["--version"]);
-    // Handle both Windows and Unix-style Git version outputs
-    // Windows: git version 2.39.2.windows.1
-    // Unix: git version 2.39.2
-    const versionMatch = gitVersion.match(/(\d+\.\d+\.\d+)/);
-    const cleanGitVersion = versionMatch ? versionMatch[1] : null;
-
-    if (cleanGitVersion && semver.lt(cleanGitVersion, "2.20.0")) {
-      errors.push(`Git version should be >= 2.20.0 for modern features. Current version: ${gitVersion}`);
-    }
+    await execa("git", ["--version"]);
   } catch {
-    errors.push("Git is not installed. Please install Git >= 2.20.0");
+    errors.push("Git is not installed. Please install Git");
   }
 
   return { errors };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,6 +1411,7 @@ __metadata:
     prettier: ^3.3.3
     rollup: 3.21.0
     rollup-plugin-auto-external: 2.0.0
+    semver: ^7.7.2
     tslib: 2.5.0
     typescript: ^5.6.3
     typescript-eslint: ^8.15.0
@@ -4353,6 +4354,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 40f6a95101e8d854357a644da1b8dd9d93ce786d5c6a77227bc69dbb17bea83d0d1d1d7c4cd5920a6df909f48e8bd8a5909869535007f90278289f2451d0292d
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.7.2":
+  version: 7.7.2
+  resolution: "semver@npm:7.7.2"
+  bin:
+    semver: bin/semver.js
+  checksum: dd94ba8f1cbc903d8eeb4dd8bf19f46b3deb14262b6717d0de3c804b594058ae785ef2e4b46c5c3b58733c99c83339068203002f9e37cfe44f7e2cc5e3d2f621
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Requirements check when using npx
- node >= 20.18.3 (see https://github.com/scaffold-eth/scaffold-eth-2/pull/1052)
- yarn >= 1.0.0 with the note that >= 2.0.0 is recommended
- git >= 2.20.0, see below why. Could be changed if needed

<details><summary>Cursor git version suggest</summary>
<p>

```
Git 2.20.0 was released in 2018 and includes many modern features
This version is widely available on all platforms
Most modern Git features and security improvements are available from this version
```

</p>
</details> 

Fixes #162