### PR TITLE
Check for git name and email

### DIFF
--- a/src/utils/system-validation.ts
+++ b/src/utils/system-validation.ts
@@ -38,6 +38,20 @@ export const checkSystemRequirements = async () => {
 
   try {
     await execa("git", ["--version"]);
+
+    try {
+      await execa("git", ["config", "user.name"]);
+    } catch {
+      errors.push("Git user.name is not configured. Please set it using: git config --global user.name 'Your Name'");
+    }
+
+    try {
+      await execa("git", ["config", "user.email"]);
+    } catch {
+      errors.push(
+        "Git user.email is not configured. Please set it using: git config --global user.email 'your.email@example.com'",
+      );
+    }
   } catch {
     errors.push("Git is not installed. Please install Git");
   }


### PR DESCRIPTION
If git `user.name` or `user.email` is not set, when initializing an instance, git tries to set name/email based on OS. It could lead to errors #157, and it is also a bad practice to use that name/email.

So I'm proposing to check for git `user.name` or `user.email` after checking if git is installed

Not sure we need to add this to the docs, I think it's not so important

Fixes #157 