### PR TITLE
Add stablecoins challenge

### DIFF
--- a/.changeset/shiny-eagles-greet.md
+++ b/.changeset/shiny-eagles-greet.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+add stablecoin challenge to curated extensions

--- a/src/extensions.json
+++ b/src/extensions.json
@@ -106,5 +106,11 @@
     "description": "SpeedRunEthereum Challenge: Prediction Markets.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
     "branch": "challenge-prediction-markets"
+  },
+  {
+    "extensionFlagValue": "challenge-stablecoins",
+    "description": "SpeedRunEthereum Challenge: Stablecoins.",
+    "repository": "https://github.com/scaffold-eth/se-2-challenges",
+    "branch": "challenge-stablecoins"
   }
 ]


### PR DESCRIPTION
This adds the `challenge-stablecoins` shortcut to the extensions.json

When this has been merged and included in a release of create-eth we will need to update the install instructions in the README here https://github.com/scaffold-eth/se-2-challenges/pull/295/ to reflect the correct version and shortcut.