### PR TITLE
backemerge 13-05-25

### DIFF
--- a/.changeset/lucky-pens-joke.md
+++ b/.changeset/lucky-pens-joke.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+up wagmi, viem and rainbow-me/rainbwkit (https://github.com/scaffold-eth/scaffold-eth-2/pull/1108)

--- a/templates/base/packages/nextjs/package.json
+++ b/templates/base/packages/nextjs/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@heroicons/react": "~2.1.5",
-    "@rainbow-me/rainbowkit": "2.2.5",
+    "@rainbow-me/rainbowkit": "2.2.7",
     "@tanstack/react-query": "~5.59.15",
     "@uniswap/sdk-core": "~5.8.2",
     "@uniswap/v2-sdk": "~4.6.1",
@@ -33,8 +33,8 @@
     "react-dom": "~19.0.0",
     "react-hot-toast": "~2.4.0",
     "usehooks-ts": "~3.1.0",
-    "viem": "2.30.0",
-    "wagmi": "2.15.4",
+    "viem": "2.31.1",
+    "wagmi": "2.15.6",
     "zustand": "~5.0.0"
   },
   "devDependencies": {

--- a/templates/base/packages/nextjs/styles/globals.css.template.mjs
+++ b/templates/base/packages/nextjs/styles/globals.css.template.mjs
@@ -1,6 +1,6 @@
 import { withDefaults } from '../../../../utils.js'
 
-const contents = ({ globalImports }) =>
+const contents = ({ globalImports, postContent }) =>
 `${globalImports}
 @import "tailwindcss";
 
@@ -122,8 +122,14 @@ const contents = ({ globalImports }) =>
 
 .link:hover {
   opacity: 80%;
-}`
+}
+
+${postContent[0] ? `
+  /* -- EXTENSION OVERRIDES -- */
+  ${postContent[0]}
+` : ''}`
 
 export default withDefaults(contents, {
-  globalImports: ''
+  globalImports: '',
+  postContent: "",
 })


### PR DESCRIPTION
### Description: 

- up wagmi, viem and rainbow-me/rainbwkit (https://github.com/scaffold-eth/scaffold-eth-2/pull/1108)


Ohh we have https://github.com/scaffold-eth/scaffold-eth-2/pull/1103 in this PR probably because last backmerge we didn't merge it as normal merge and instead did squash and merge. 

I checked the code and we already have the changes from that PR 🙌 

> NOTE: We should do a normal merge commit instead of squash and merge


### To test: 

```
yarn build:dev && yarn cli -e https://github.com/scaffold-eth/create-eth-extensions/tree/update-example-globall-css
```