### PR TITLE
GitHub: Fetch solidity framework folder correctly for default branch

### DIFF
--- a/.changeset/modern-rabbits-knock.md
+++ b/.changeset/modern-rabbits-knock.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+Fetch solidity framework folder correctly for default git branch

--- a/src/utils/external-extensions.ts
+++ b/src/utils/external-extensions.ts
@@ -167,7 +167,8 @@ export const getSolidityFrameworkDirsFromExternalExtension = async (
   const { ownerName, repoName } = deconstructGithubUrl(repository);
 
   const frameworkChecks = solidityFrameworks.map(async framework => {
-    const githubUrl = `https://github.com/${ownerName}/${repoName}/tree/${branch}/extension/packages/${framework}`;
+    const branchOrHead = branch ? `tree/${branch}` : "blob/HEAD";
+    const githubUrl = `https://github.com/${ownerName}/${repoName}/${branchOrHead}/extension/packages/${framework}`;
     try {
       const res = await fetch(githubUrl);
       if (res.status === 200) return framework as SolidityFramework;


### PR DESCRIPTION
Request for fetching the available solidity framework was failing when using the default branch (`branch` was empty)

This PR fixes it using blob/HEAD.