### PR TITLE
Migration script: files priority

### DIFF
--- a/src/dev/migrate-to-beta.ts
+++ b/src/dev/migrate-to-beta.ts
@@ -261,7 +261,22 @@ const main = async (rawArgs: string[]) => {
 
     let totalIssues = 0;
 
-    for (const comparison of comparisons) {
+    // Sort comparisons by priority: no issues first, then only new args, then other issues
+    const getPriority = (comparison: ArgsComparison): number => {
+      const hasRenamed = comparison.renamedArgs.length > 0;
+      const hasNew = comparison.newArgs.length > 0;
+      const hasMissing = comparison.missingArgs.length > 0;
+
+      if (!hasRenamed && !hasNew && !hasMissing) return 0; // No issues
+      if (hasNew && !hasRenamed && !hasMissing) return 1; // Only new args
+      return 2; // Other issues (renamed, missing, or mixed)
+    };
+
+    const sortedComparisons = comparisons.sort((a, b) => {
+      return getPriority(a) - getPriority(b);
+    });
+
+    for (const comparison of sortedComparisons) {
       const hasIssues =
         comparison.renamedArgs.length > 0 || comparison.newArgs.length > 0 || comparison.missingArgs.length > 0;
 


### PR DESCRIPTION
When migrating with the script extension, we're getting logs of the files in the order which is not depend on errors/warnings. So how it works now: 
1. I use script. I see the logs, I **scroll** for errors
2. I fix argument(s) in some file
3. I use script to recheck if I did it right, and errors disappear.
4. I **scroll** for a new error. Go to 1

---

This PR changes the order of the files in the logs:
1. Files with no issues
2. Files with only new args warnings (which are not always needed)
3. Files with errors which 100% needed to be fixed.

<details><summary>Logs example</summary>
<p>

```
yarn migrate-to-beta externalExtensions/se-2-challenges


Analyzing extension: externalExtensions/se-2-challenges/extension
Comparing with beta version: externalExtensions/create-eth-extensions-beta/extension
Scanning for .args.mjs files...

externalExtensions/se-2-challenges/extension/packages/nextjs/app/layout.tsx.args.mjs
  ✔︎ No issues found

externalExtensions/se-2-challenges/extension/packages/nextjs/components/Header.tsx.args.mjs
  ✔︎ No issues found

externalExtensions/se-2-challenges/extension/packages/nextjs/styles/globals.css.args.mjs
  ✔︎ No issues found

externalExtensions/se-2-challenges/extension/README.md.args.mjs
  ⚠ New arguments in beta:
    + fullContentOverride

externalExtensions/se-2-challenges/extension/packages/nextjs/app/page.tsx.args.mjs
  ⚠ New arguments in beta:
    + fullContentOverride
    + preContent

externalExtensions/se-2-challenges/extension/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.args.mjs
  ⚠ New arguments in beta:
    + extraProviders
    + preContent

externalExtensions/se-2-challenges/extension/packages/nextjs/utils/scaffold-eth/getMetadata.ts.args.mjs
  ⚠ New arguments in beta:
    + metadataOverrides
    + preContent

externalExtensions/se-2-challenges/extension/packages/nextjs/next.config.ts.args.mjs
  ⚠ New arguments in beta:
    + finalNextConfigName
    + postConfigContent
    + preContent
  ✖ Arguments removed in beta:
    - ignoreTsAndLintBuildErrors


Summary: Analyzed 8 files
⚠ 5 files have migration issues
Review the output above for detailed migration guidance
```

</p>
</details> 

So how workflow looks for me now:
1. Use script. Take last file with error (no scroll)
2. Fix it. Use script. Repeat