### PR TITLE
extension list: numbered challenges => not numbered challenges

### DIFF
--- a/src/extensions.json
+++ b/src/extensions.json
@@ -42,7 +42,7 @@
     "branch": "erc-721"
   },
   {
-    "extensionFlagValue": "challenge-simple-nft",
+    "extensionFlagValue": "challenge-simple-nft-example",
     "description": "SpeedRunEthereum Challenge: Simple NFT Example.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
     "branch": "challenge-simple-nft-example"

--- a/src/extensions.json
+++ b/src/extensions.json
@@ -45,7 +45,7 @@
     "extensionFlagValue": "challenge-simple-nft",
     "description": "SpeedRunEthereum Challenge: Simple NFT Example.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
-    "branch": "challenge-simple-nft"
+    "branch": "challenge-simple-nft-example"
   },
   {
     "extensionFlagValue": "challenge-decentralized-staking",

--- a/src/extensions.json
+++ b/src/extensions.json
@@ -42,52 +42,52 @@
     "branch": "erc-721"
   },
   {
-    "extensionFlagValue": "challenge-0-simple-nft",
-    "description": "SpeedRunEthereum Challenge 0: Simple NFT Example.",
+    "extensionFlagValue": "challenge-simple-nft",
+    "description": "SpeedRunEthereum Challenge: Simple NFT Example.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
-    "branch": "challenge-0-simple-nft"
+    "branch": "challenge-simple-nft"
   },
   {
-    "extensionFlagValue": "challenge-1-decentralized-staking",
-    "description": "SpeedRunEthereum Challenge 1: Decentralized Staking App.",
+    "extensionFlagValue": "challenge-decentralized-staking",
+    "description": "SpeedRunEthereum Challenge: Decentralized Staking App.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
-    "branch": "challenge-1-decentralized-staking"
+    "branch": "challenge-decentralized-staking"
   },
   {
-    "extensionFlagValue": "challenge-2-token-vendor",
-    "description": "SpeedRunEthereum Challenge 2: Token Vendor.",
+    "extensionFlagValue": "challenge-token-vendor",
+    "description": "SpeedRunEthereum Challenge: Token Vendor.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
-    "branch": "challenge-2-token-vendor"
+    "branch": "challenge-token-vendor"
   },
   {
-    "extensionFlagValue": "challenge-3-dice-game",
-    "description": "SpeedRunEthereum Challenge 3: Dice Game.",
+    "extensionFlagValue": "challenge-dice-game",
+    "description": "SpeedRunEthereum Challenge: Dice Game.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
-    "branch": "challenge-3-dice-game"
+    "branch": "challenge-dice-game"
   },
   {
-    "extensionFlagValue": "challenge-4-dex",
-    "description": "SpeedRunEthereum Challenge 4: Build a DEX.",
+    "extensionFlagValue": "challenge-dex",
+    "description": "SpeedRunEthereum Challenge: Build a DEX.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
-    "branch": "challenge-4-dex"
+    "branch": "challenge-dex"
   },
   {
-    "extensionFlagValue": "challenge-5-state-channels",
-    "description": "SpeedRunEthereum Challenge 5: A State Channel Application.",
+    "extensionFlagValue": "challenge-state-channels",
+    "description": "SpeedRunEthereum Challenge: A State Channel Application.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
-    "branch": "challenge-5-state-channels"
+    "branch": "challenge-state-channels"
   },
   {
-    "extensionFlagValue": "challenge-6-multisig",
-    "description": "SpeedRunEthereum Challenge 6: Multisig Wallet.",
+    "extensionFlagValue": "challenge-multisig",
+    "description": "SpeedRunEthereum Challenge: Multisig Wallet.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
-    "branch": "challenge-6-multisig"
+    "branch": "challenge-multisig"
   },
   {
-    "extensionFlagValue": "challenge-7-svg-nft",
-    "description": "SpeedRunEthereum Challenge 7: SVG NFT.",
+    "extensionFlagValue": "challenge-svg-nft",
+    "description": "SpeedRunEthereum Challenge: SVG NFT.",
     "repository": "https://github.com/scaffold-eth/se-2-challenges",
-    "branch": "challenge-7-svg-nft"
+    "branch": "challenge-svg-nft"
   },
   {
     "extensionFlagValue": "challenge-over-collateralized-lending",


### PR DESCRIPTION
As part of:
- https://github.com/BuidlGuidl/SpeedRunEthereum-v2/issues/229
- https://github.com/scaffold-eth/se-2-challenges/pull/323 (to 329)
- https://github.com/austintgriffith/speedrun-grader/pull/24

We should merge this when all the above is merged and release a new version + update challenges README. We can do it in steps if we want.

We want to remove the numbers from the curated extensions (challenges)

