### PR TITLE
ci: add permisison to have oidc flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: write # Required for changesets to create commits and tags
+  pull-requests: write # Required for changesets to open/update release PRs
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -30,4 +35,3 @@ jobs:
           publish: yarn changeset:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description: 

Npm has revoked all the classic token permanantely checkout [this](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/). And now they suggest to use OIDC flow for secure publishing. 


The problem with classic token flow was it might get leaked via logs in CI or any mishappen, if the attacker gets access to it he can easily publish anything to that package. 

But with OIDC flow: 

1. I have confiigured the repo and release workflow file on npm UI 
2. In github actions (this PR) asking github to create an OIDC id token 

So now how the whole thing work is, 

Github here the identity provider (IdP), is generating an signed ID token (JWT) which contains claim like: 
- who the issuer is (iss) — “token came from GitHub”
- who it’s about (sub) — “this specific workflow run identity”
- audience (aud) — “intended for npm”
- expiry (exp) — “valid for only a short time”
- plus extra claims like repository/workflow ref, environment, etc (IdP-specific)

And here the npm relying part (RP), It trusts GitHub’s token if it’s valid and matches expected claims by comparing with what we have configured in UI and the token generate during publication. 

This way the only way to publish package is via github. If we / attacker try to publish it via locally or any other method it won't work. 

Incase we want to publish package via local flow we use [their new cli tool with 2fa](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/#new-cli-token-management-tool-for-granular-tokens) and do that 🙌