### PR TITLE
Update action to use latest node version 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 16.x
-        uses: actions/setup-node@v3
+      - name: Setup node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: "24"
+          cache: yarn
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn --immutable
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
### Description: 

The https://github.com/scaffold-eth/create-eth/actions/runs/20330819049/job/58405403070 is fialing and I htink maybe it's because we are using older version of node which uses older version of npm