### PR TITLE
fix changeset action fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,6 @@ jobs:
         uses: changesets/action@v1.5.3
         with:
           publish: yarn changeset:release
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description: 

This occurs because the action's internal PR lookup returns empty (Existing pull requests: []) and then it tries to createa new PR instead of force pushing the update

There is also a similar issue reported https://github.com/changesets/action/issues/396

I tried using `commit-mode: github-api`  so that we try to fetch the existing PR more in github way. Like according to my research it seems that there is some issue with github / changeset action not able to fetch the existing PR because in most of the days it works (it's able to fetch the PR, recognize it and then force push) but on other days it's just fails because it gets (Existing pull requests: [])
