### PR TITLE
feat: add --project and --name CLI flags for setting project name

### DIFF
--- a/src/utils/parse-arguments-into-options.ts
+++ b/src/utils/parse-arguments-into-options.ts
@@ -25,6 +25,10 @@ export async function parseArgumentsIntoOptions(
       "--extension": String,
       "-e": "--extension",
 
+      "--project": String,
+      "-p": "--project",
+      "--name": "--project",
+
       "--help": Boolean,
       "-h": "--help",
     },
@@ -39,7 +43,7 @@ export async function parseArgumentsIntoOptions(
 
   const help = args["--help"] ?? false;
 
-  let project: string | null = args._[0] ?? null;
+  let project: string | null = args["--project"] ?? args._[0] ?? null;
 
   // use the original extension arg
   const extensionName = args["--extension"];

--- a/src/utils/show-help-message.ts
+++ b/src/utils/show-help-message.ts
@@ -2,9 +2,10 @@ import chalk from "chalk";
 
 export const showHelpMessage = () => {
   console.log(` ${chalk.bold.blue("Usage:")}
-    ${chalk.bold.green("npx create-eth<@version>")} ${chalk.gray("[--skip | --skip-install] [-s <solidity-framework> | --solidity-framework <solidity-framework>] [-e <extension> | --extension <extension>] [-h | --help]")}
+    ${chalk.bold.green("npx create-eth<@version>")} ${chalk.gray("[-p <project-name> | --project <project-name>] [--skip | --skip-install] [-s <solidity-framework> | --solidity-framework <solidity-framework>] [-e <extension> | --extension <extension>] [-h | --help]")}
 `);
   console.log(` ${chalk.bold.blue("Options:")}
+    ${chalk.gray("-p, --project, --name")}         Set project name
     ${chalk.gray("--skip, --skip-install")}       Skip packages installation
     ${chalk.gray("-s, --solidity-framework")}     Choose solidity framework
     ${chalk.gray("-e, --extension")}              Add curated or third-party extension


### PR DESCRIPTION
## Summary

- Adds `--project`, `-p`, and `--name` CLI flags to set the project name directly from the command line
- Previously, project name could only be passed as a positional argument (`npx create-eth my-project`)
- Now supports both positional and named flags for more explicit usage

## Usage

```bash
# Positional (existing behavior, still works)
npx create-eth my-dapp

# Named flags (new)
npx create-eth --project my-dapp
npx create-eth -p my-dapp
npx create-eth --name my-dapp
```

This is useful for scripting and automation where named flags are clearer than positional arguments.

## Test plan

- [x] `yarn build` succeeds
- [x] `yarn cli --project testapp --solidity-framework foundry --skip-install` creates project correctly
- [x] Positional argument still works: `yarn cli testapp --solidity-framework foundry --skip-install`
- [x] Help message (`yarn cli --help`) shows new options