### PR TITLE
feat: reduce default pollingInterval from 30000ms to 3000ms

### DIFF
--- a/templates/base/packages/nextjs/scaffold.config.ts.template.mjs
+++ b/templates/base/packages/nextjs/scaffold.config.ts.template.mjs
@@ -2,7 +2,7 @@ import { withDefaults, stringify, deepMerge } from "../../../../templates/utils.
 
 const defaultScaffoldConfig = {
     targetNetworks: ["$$chains.mainnet$$"],
-    pollingInterval: 30000,
+    pollingInterval: 3000,
     alchemyApiKey: "$$process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || DEFAULT_ALCHEMY_API_KEY$$",
     rpcOverrides: {},
     walletConnectProjectId: "$$process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || '3a8170812b534d0ff9d794f19a901d64'$$",
@@ -41,7 +41,7 @@ export const DEFAULT_ALCHEMY_API_KEY = "cR4WnXePioePZ5fFrnSiR";
 
 const scaffoldConfig = ${stringify(finalConfig, {
   targetNetworks: "The networks on which your DApp is live",
-  pollingInterval: "The interval at which your front-end polls the RPC servers for new data (it has no effect if you only target the local network (default is 4000))",
+  pollingInterval: "The interval at which your front-end polls the RPC servers for new data (it has no effect if you only target the local network (default is 3000))",
   alchemyApiKey: "This is ours Alchemy's default API key.\nYou can get your own at https://dashboard.alchemyapi.io\nIt's recommended to store it in an env variable:\n.env.local for local testing, and in the Vercel/system env config for live apps.",
   walletConnectProjectId: "This is ours WalletConnect's default project ID.\nYou can get your own at https://cloud.walletconnect.com\nIt's recommended to store it in an env variable:\n.env.local for local testing, and in the Vercel/system env config for live apps.",
   rpcOverrides: "If you want to use a different RPC for a specific network, you can add it here.\nThe key is the chain ID, and the value is the HTTP RPC URL",


### PR DESCRIPTION
## Summary

- Reduces the default `pollingInterval` in `scaffold.config.ts` from 30000ms (30 seconds) to 3000ms (3 seconds)
- Updates the comment to reflect the new default value

## Motivation

The 30 second polling interval makes for a poor dev experience - the UI feels slow and unresponsive when waiting for state updates. Almost every developer changes this to a lower value immediately after starting a new project. 

Reducing the default to 3 seconds provides a snappier UX out of the box while still being reasonable for RPC rate limits.

## Test plan

- [x] Verified the template file generates correct config with new value