### PR TITLE
fix: VerifyAll fails when contract name differs from source file name

### DIFF
--- a/.changeset/slow-files-pay.md
+++ b/.changeset/slow-files-pay.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+foundry: fix verfiyAll script

--- a/templates/solidity-frameworks/foundry/packages/foundry/script/VerifyAll.s.sol
+++ b/templates/solidity-frameworks/foundry/packages/foundry/script/VerifyAll.s.sol
@@ -90,10 +90,22 @@ contract VerifyAll is Script {
         }
     }
 
-    function _getCompiledBytecode(string memory contractName) internal view returns (string memory compiledBytecode) {
+    function _getCompiledBytecode(string memory contractName) internal returns (string memory compiledBytecode) {
         string memory root = vm.projectRoot();
-        string memory path = string.concat(root, "/out/", contractName, ".sol/", contractName, ".json");
-        compiledBytecode = vm.readFile(path);
+        string memory defaultPath = string.concat(root, "/out/", contractName, ".sol/", contractName, ".json");
+
+        try vm.readFile(defaultPath) returns (string memory content) {
+            compiledBytecode = content;
+        } catch {
+            string[] memory inputs = new string[](3);
+            inputs[0] = "bash";
+            inputs[1] = "-c";
+            inputs[2] = string.concat(
+                "find '", root, "/out' -name '", contractName, ".json' -not -path '*/build-info/*' -print -quit | tr -d '\\n'"
+            );
+            FfiResult memory f = tempVm(address(vm)).tryFfi(inputs);
+            compiledBytecode = vm.readFile(string(f.stdout));
+        }
     }
 
     function searchStr(uint96 idx, string memory searchKey) internal pure returns (string memory) {


### PR DESCRIPTION
## Summary

- `VerifyAll.s.sol`'s `_getCompiledBytecode` assumed compiled artifacts live at `out/{contractName}.sol/{contractName}.json`, but Foundry organizes artifacts by **source file name**, not contract name. When they differ (e.g. contract `ORA` defined in `OracleToken.sol`), the script reverts with a file-not-found error.
- The fix tries the default path first, then falls back to searching the `out/` directory via `find` to locate the correct artifact.

## How to test

1. Create a project with a contract whose name differs from its source file name (e.g. `contract ORA` inside `OracleToken.sol`)
2. Deploy to a testnet: `yarn deploy --network sepolia`
3. Run `yarn verify --network sepolia`
4. **Before fix**: reverts with `vm.readFile: failed to open file "...out/ORA.sol/ORA.json": No such file or directory`
5. **After fix**: verification proceeds correctly, finding the artifact at `out/OracleToken.sol/ORA.json`

## Things to look out for

- The function signature changes from `internal view` to `internal` (dropping `view`) because the fallback path uses `tryFfi`. The caller `_verifyContract` is already non-view, so this is safe.
- The `find` fallback excludes `build-info/` to avoid matching the wrong JSON files.


Made with [Cursor](https://cursor.com)