### PR TITLE
fix: foundry block explorer contract details bytecode/opcodes

### DIFF
--- a/.changeset/fix-foundry-blockexplorer-bytecode.md
+++ b/.changeset/fix-foundry-blockexplorer-bytecode.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+fix: foundry block explorer contract details page not showing bytecode/opcodes

--- a/templates/base/packages/nextjs/app/blockexplorer/address/[address]/page.tsx.template.mjs
+++ b/templates/base/packages/nextjs/app/blockexplorer/address/[address]/page.tsx.template.mjs
@@ -23,15 +23,19 @@ type PageProps = {
 ${
   isFoundry
     ? `function fetchByteCodeAndAssembly(foundryOutDirectory: string, contractName: string) {
-  // Foundry organizes artifacts by source file name, not contract name, so we scan all .sol dirs.
-  const solDirs = fs.readdirSync(foundryOutDirectory).filter(entry => entry.endsWith(".sol"));
+  // Foundry organizes artifacts by source file name, not contract name.
+  // Try the default path first, then fall back to scanning all .sol dirs (skipping build-info).
+  let artifactPath = path.join(foundryOutDirectory, \`\${contractName}.sol\`, \`\${contractName}.json\`);
 
-  let artifactPath = "";
-  for (const solDir of solDirs) {
-    const candidate = path.join(foundryOutDirectory, solDir, \`\${contractName}.json\`);
-    if (fs.existsSync(candidate)) {
-      artifactPath = candidate;
-      break;
+  if (!fs.existsSync(artifactPath)) {
+    artifactPath = "";
+    const solDirs = fs.readdirSync(foundryOutDirectory).filter(entry => entry.endsWith(".sol"));
+    for (const solDir of solDirs) {
+      const candidate = path.join(foundryOutDirectory, solDir, \`\${contractName}.json\`);
+      if (fs.existsSync(candidate)) {
+        artifactPath = candidate;
+        break;
+      }
     }
   }
 

--- a/templates/base/packages/nextjs/app/blockexplorer/address/[address]/page.tsx.template.mjs
+++ b/templates/base/packages/nextjs/app/blockexplorer/address/[address]/page.tsx.template.mjs
@@ -23,9 +23,19 @@ type PageProps = {
 ${
   isFoundry
     ? `function fetchByteCodeAndAssembly(foundryOutDirectory: string, contractName: string) {
-  const artifactPath = path.join(foundryOutDirectory, \`\${contractName}.sol\`, \`\${contractName}.json\`);
+  // Foundry organizes artifacts by source file name, not contract name, so we scan all .sol dirs.
+  const solDirs = fs.readdirSync(foundryOutDirectory).filter(entry => entry.endsWith(".sol"));
 
-  if (!fs.existsSync(artifactPath)) {
+  let artifactPath = "";
+  for (const solDir of solDirs) {
+    const candidate = path.join(foundryOutDirectory, solDir, \`\${contractName}.json\`);
+    if (fs.existsSync(candidate)) {
+      artifactPath = candidate;
+      break;
+    }
+  }
+
+  if (!artifactPath) {
     return { bytecode: "", assembly: "" };
   }
 

--- a/templates/base/packages/nextjs/app/blockexplorer/address/[address]/page.tsx.template.mjs
+++ b/templates/base/packages/nextjs/app/blockexplorer/address/[address]/page.tsx.template.mjs
@@ -4,6 +4,8 @@ const contents = ({ solidityFramework, artifactsDirName }) => {
   if (!solidityFramework[0]) {
     solidityFramework[0] = "hardhat";
   }
+  const isFoundry = solidityFramework[0] === "foundry";
+
   return `
 import fs from "fs";
 import path from "path";
@@ -18,7 +20,23 @@ type PageProps = {
   params: Promise<{ address: Address }>;
 };
 
-async function fetchByteCodeAndAssembly(buildInfoDirectory: string, contractPath: string) {
+${
+  isFoundry
+    ? `function fetchByteCodeAndAssembly(foundryOutDirectory: string, contractName: string) {
+  const artifactPath = path.join(foundryOutDirectory, \`\${contractName}.sol\`, \`\${contractName}.json\`);
+
+  if (!fs.existsSync(artifactPath)) {
+    return { bytecode: "", assembly: "" };
+  }
+
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+  const bytecode: string = artifact?.bytecode?.object ?? "";
+  const assembly: string = artifact?.opcodes ?? artifact?.bytecode?.opcodes ?? "";
+
+  return { bytecode, assembly };
+}`
+    : `async function fetchByteCodeAndAssembly(buildInfoDirectory: string, contractName: string) {
+  const contractPath = \`contracts/\${contractName}.sol\`;
   const buildInfoFiles = fs.readdirSync(buildInfoDirectory);
   let bytecode = "";
   let assembly = "";
@@ -42,6 +60,7 @@ async function fetchByteCodeAndAssembly(buildInfoDirectory: string, contractPath
   }
 
   return { bytecode, assembly };
+}`
 }
 
 const getContractData = async (address: Address) => {
@@ -52,9 +71,7 @@ const getContractData = async (address: Address) => {
     return null;
   }
 
-  let contractPath = "";
-
-  const buildInfoDirectory = path.join(
+  const artifactsDirectory = path.join(
     __dirname,
     "..",
     "..",
@@ -64,28 +81,29 @@ const getContractData = async (address: Address) => {
     "..",
     "..",
     "${solidityFramework[0]}",
-    "${artifactsDirName[0]}",
-    "build-info",
+    "${artifactsDirName[0]}"${isFoundry ? "" : `,
+    "build-info"`},
   );
 
-  if (!fs.existsSync(buildInfoDirectory)) {
-    throw new Error(\`Directory \${buildInfoDirectory} not found.\`);
+  if (!fs.existsSync(artifactsDirectory)) {
+    throw new Error(\`Directory \${artifactsDirectory} not found.\`);
   }
 
+  let matchedContractName = "";
   const deployedContractsOnChain = contracts[chainId];
   for (const [contractName, contractInfo] of Object.entries(deployedContractsOnChain)) {
     if (contractInfo.address.toLowerCase() === address.toLowerCase()) {
-      contractPath = \`contracts/\${contractName}.sol\`;
+      matchedContractName = contractName;
       break;
     }
   }
 
-  if (!contractPath) {
+  if (!matchedContractName) {
     // No contract found at this address
     return null;
   }
 
-  const { bytecode, assembly } = await fetchByteCodeAndAssembly(buildInfoDirectory, contractPath);
+  const { bytecode, assembly } = await fetchByteCodeAndAssembly(artifactsDirectory, matchedContractName);
 
   return { bytecode, assembly };
 };
@@ -105,7 +123,8 @@ const AddressPage = async (props: PageProps) => {
   return <AddressComponent address={address} contractData={contractData} />;
 };
 
-export default AddressPage;`};
+export default AddressPage;`;
+};
 
 export default withDefaults(contents, {
   artifactsDirName: "artifacts",

--- a/templates/solidity-frameworks/foundry/packages/foundry/foundry.toml.template.mjs
+++ b/templates/solidity-frameworks/foundry/packages/foundry/foundry.toml.template.mjs
@@ -11,6 +11,7 @@ src = 'contracts'
 out = 'out'
 libs = ['lib', 'node_modules']
 fs_permissions = [{ access = "read-write", path = "./"}]
+extra_output = ["evm.bytecode.opcodes"]
 ${extraProfileDefaults.filter(Boolean).join("\n")}
 
 [rpc_endpoints]


### PR DESCRIPTION
## To test: 

```
yarn build && yarn cli 
```

## Summary
- Foundry projects were showing empty bytecode/opcodes on the block explorer contract details page (`/blockexplorer/address/<address>`). The page scanned `out/build-info/*.json` using the hardhat schema (`buildInfo.output.contracts[contractPath]`), which no longer matches foundry's build-info layout.
- Switched foundry to read the per-contract artifact at `out/<Name>.sol/<Name>.json` directly (`bytecode.object` + `opcodes`).
- Added `extra_output = ["evm.bytecode.opcodes"]` to `foundry.toml` so forge includes opcodes in the artifact.
- Hardhat path is behaviorally unchanged — only a small refactor so both frameworks share the outer `getContractData` scaffolding.

## Changes
- `templates/solidity-frameworks/foundry/packages/foundry/foundry.toml.template.mjs` — add `extra_output`.
- `templates/base/packages/nextjs/app/blockexplorer/address/[address]/page.tsx.template.mjs` — branch `fetchByteCodeAndAssembly` on `solidityFramework[0] === "foundry"`; keep function name and call site identical for both frameworks.

## Test plan
- [ ] Scaffold a foundry project, deploy `YourContract`, visit `/blockexplorer/address/<contract-address>` — bytecode and opcodes are shown.
- [ ] Scaffold a hardhat project, deploy `YourContract`, visit the same page — bytecode and opcodes still shown (regression check).
- [ ] Scaffold a foundry project that has never been compiled — page renders without throwing (artifact missing case).