### PR TITLE
fix(foundry): resolve ABI when source file name differs from contract name

### DIFF
--- a/.changeset/foundry-generate-ts-abis-mismatched-names.md
+++ b/.changeset/foundry-generate-ts-abis-mismatched-names.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+fix(foundry): generateTsAbis resolves artifacts when source file name differs from contract name

--- a/templates/solidity-frameworks/foundry/packages/foundry/scripts-js/generateTsAbis.js
+++ b/templates/solidity-frameworks/foundry/packages/foundry/scripts-js/generateTsAbis.js
@@ -90,19 +90,20 @@ function getDeploymentHistory(broadcastPath) {
 }
 
 function getArtifactOfContract(contractName) {
-  const current_path_to_artifacts = join(
-    __dirname,
-    "..",
-    `out/${contractName}.sol`
-  );
+  const outDir = join(__dirname, "..", "out");
+  const conventional = join(outDir, `${contractName}.sol`, `${contractName}.json`);
+  if (existsSync(conventional)) {
+    return JSON.parse(readFileSync(conventional));
+  }
 
-  if (!existsSync(current_path_to_artifacts)) return null;
-
-  const artifactJson = JSON.parse(
-    readFileSync(`${current_path_to_artifacts}/${contractName}.json`)
-  );
-
-  return artifactJson;
+  // Fallback: file name differs from contract name. Scan out/*.sol/ for <contractName>.json.
+  for (const dir of getDirectories(outDir)) {
+    const candidate = join(outDir, dir, `${contractName}.json`);
+    if (existsSync(candidate)) {
+      return JSON.parse(readFileSync(candidate));
+    }
+  }
+  return null;
 }
 
 function getInheritedFromContracts(artifact) {


### PR DESCRIPTION
Noticed by Damu [here](https://github.com/scaffold-eth/se-2-challenges/pull/440#discussion_r3222286262) 

  ## Summary
  - `generateTsAbis.js` looked up artifacts at `out/<ContractName>.sol/<ContractName>.json`, so contracts whose source file name differs from the contract name (e.g.
  `OracleToken.sol` containing contract `ORA`) were silently skipped and never appeared in `deployedContracts.ts` (or the debug page).
  - Fall back to scanning `out/*.sol/` for `<ContractName>.json` when the conventional path doesn't exist. Fast path unchanged when names match.

  ## Test plan
  - [ ] In a Foundry extension, rename a contract so it differs from its file name (e.g. file `Foo.sol` with `contract Bar`), deploy via a script, verify `Bar` appears in `packages/nextjs/contracts/deployedContracts.ts` and on the debug page. Example extension: https://github.com/scaffold-eth/se-2-challenges/pull/440 . `OracleToken.sol` file with contract named `ORA`
  - [ ] Regression: verify contracts where file name matches contract name still resolve (fast path).

### Test commands

```
yarn build:dev
```

```
yarn cli -e https://github.com/scaffold-eth/se-2-challenges/tree/challenge-oracles-foundry-v2 -s foundry --dev
```


Related #411 