### PR TITLE
backmerge 18-05-26

### DIFF
--- a/.changeset/new-alchemy-key.md
+++ b/.changeset/new-alchemy-key.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+- new Alchemy key (https://github.com/scaffold-eth/scaffold-eth-2/pull/1287)

--- a/templates/base/packages/nextjs/scaffold.config.ts.template.mjs
+++ b/templates/base/packages/nextjs/scaffold.config.ts.template.mjs
@@ -37,7 +37,7 @@ export type BaseConfig = {
 
 export type ScaffoldConfig = BaseConfig ${extraConfigTypeName[0] ? `& ${extraConfigTypeName[0]}` : ''};
 
-export const DEFAULT_ALCHEMY_API_KEY = "cR4WnXePioePZ5fFrnSiR";
+export const DEFAULT_ALCHEMY_API_KEY = "IZYEU2cWBgnFmgiTAgpWD";
 
 const scaffoldConfig = ${stringify(finalConfig, {
   targetNetworks: "The networks on which your DApp is live",

--- a/templates/solidity-frameworks/foundry/packages/foundry/.env.example
+++ b/templates/solidity-frameworks/foundry/packages/foundry/.env.example
@@ -12,7 +12,7 @@
 # be auto filled when run `yarn generate`.
 
 # Alchemy rpc URL is used while deploying the contracts to some testnets/mainnets, checkout `foundry.toml` for it's use.
-ALCHEMY_API_KEY=cR4WnXePioePZ5fFrnSiR
+ALCHEMY_API_KEY=IZYEU2cWBgnFmgiTAgpWD
 # Etherscan API key is used to verify the contract on etherscan.
 ETHERSCAN_API_KEY=DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW
 # Default account for localhost / use "scaffold-eth-custom" if you wish to use a generated account or imported account

--- a/templates/solidity-frameworks/foundry/packages/foundry/.env.template.mjs
+++ b/templates/solidity-frameworks/foundry/packages/foundry/.env.template.mjs
@@ -7,7 +7,7 @@ const contents = () =>
 # but we recommend getting your own API Keys for Production Apps.
 
 # Alchemy rpc URL is used while deploying the contracts to some testnets/mainnets, checkout \`foundry.toml\` for it's use.
-ALCHEMY_API_KEY=cR4WnXePioePZ5fFrnSiR
+ALCHEMY_API_KEY=IZYEU2cWBgnFmgiTAgpWD
 
 # Etherscan API key is used to verify the contract on etherscan.
 ETHERSCAN_API_KEY=DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW

--- a/templates/solidity-frameworks/foundry/packages/foundry/scripts-js/checkAccountBalance.js
+++ b/templates/solidity-frameworks/foundry/packages/foundry/scripts-js/checkAccountBalance.js
@@ -9,7 +9,7 @@ import { parse } from "toml";
 import { ethers } from "ethers";
 
 const ALCHEMY_API_KEY =
-  process.env.ALCHEMY_API_KEY || "cR4WnXePioePZ5fFrnSiR";
+  process.env.ALCHEMY_API_KEY || "IZYEU2cWBgnFmgiTAgpWD";
 
 // Load environment variables
 const __filename = fileURLToPath(import.meta.url);

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -134,7 +134,7 @@ ${preContent[0] || ''}
 
 // If not set, it uses ours Alchemy's default API key.
 // You can get your own at https://dashboard.alchemyapi.io
-const providerApiKey = process.env.ALCHEMY_API_KEY || "cR4WnXePioePZ5fFrnSiR";
+const providerApiKey = process.env.ALCHEMY_API_KEY || "IZYEU2cWBgnFmgiTAgpWD";
 // If not set, it uses the hardhat account 0 private key.
 // You can generate a random account with \`yarn generate\` or \`yarn account:import\` to import your existing PK
 const deployerPrivateKey =


### PR DESCRIPTION
- new Alchemy key (https://github.com/scaffold-eth/scaffold-eth-2/pull/1287)

Cherry-picked single commit from SE-2 main: https://github.com/scaffold-eth/scaffold-eth-2/commit/69828b16f429526ff28bbc382b02c98e54e55a44

Note: in addition to the two files changed upstream (`hardhat.config.ts`, `scaffold.config.ts`), the new key was also applied to create-eth's Foundry templates (`.env.template.mjs`, `.env.example`, `checkAccountBalance.js`) which carry the same default key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)