### PR TITLE
fix: update for sre extensions

### DIFF
--- a/templates/example-contracts/hardhat/packages/hardhat/deploy/00_deploy_your_contract.ts
+++ b/templates/example-contracts/hardhat/packages/hardhat/deploy/00_deploy_your_contract.ts
@@ -1,5 +1,4 @@
-import { deployScript } from "../rocketh/deploy.js";
-import * as artifacts from "../generated/artifacts/index.js";
+import { deployScript, artifacts } from "../rocketh/deploy.js";
 
 /**
  * Deploys a contract named "YourContract" using the deployer account and

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/hardhat.config.ts.template.mjs
@@ -3,17 +3,17 @@ import { withDefaults, stringify, deepMerge } from "../../../../utils.js";
 const defaultConfig = {
   plugins: '$$[hardhatToolbox, HardhatDeploy]$$',
   solidity: {
-    profiles: {
-      default: {
+    compilers: [
+      {
         version: "0.8.30",
         settings: {
           optimizer: {
             enabled: true,
             runs: 200,
           },
-        },
-      },
-    },
+        }
+      }
+    ],
   },
   generateTypedArtifacts: {
     destinations: [

--- a/templates/solidity-frameworks/hardhat/packages/hardhat/rocketh/deploy.ts
+++ b/templates/solidity-frameworks/hardhat/packages/hardhat/rocketh/deploy.ts
@@ -3,3 +3,5 @@ import { setupDeployScripts } from "rocketh";
 
 const { deployScript } = setupDeployScripts<Extensions, Accounts, Data>(extensions);
 export { deployScript };
+
+export * as artifacts from "../generated/artifacts/index.js";


### PR DESCRIPTION
PR to backmerge branch #427

We need those changes for SRE challenges hh v3 migration.

1. Optional but preferred. Reexport artifacts from rocketh file https://github.com/scaffold-eth/create-eth/pull/427#issuecomment-4519658980
2. Hardhat v3 doesnt allow to use both `profiles` and `compilers` in hardhat config. So challenges with override like this become broken https://github.com/scaffold-eth/se-2-challenges/blob/7ff36fa18b7733b7e8ffe55a0325077355bab07b/extension/packages/hardhat/hardhat.config.ts.args.mjs#L3. So just using compilers fixes the issue

~~Note: I still didn't test zk challenge so there's a chance this PR will be updated.~~ Created it so it could be possible to test other challenges migrations