### PR TITLE
fix(nextjs-template): stop excluding contracts/ from format script

### DIFF
--- a/.changeset/fix-format-include-contracts.md
+++ b/.changeset/fix-format-include-contracts.md
@@ -1,0 +1,7 @@
+---
+"create-eth": patch
+---
+
+fix(nextjs-template): stop excluding contracts/ from format script
+
+Users paste ABIs into externalContracts.ts and expect prettier to format on save / yarn format. The contracts/ exclusion was meant for generated deployedContracts.ts but caught externalContracts.ts too.

--- a/templates/base/packages/nextjs/package.json
+++ b/templates/base/packages/nextjs/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "check-types": "tsc --noEmit --incremental",
     "dev": "next dev",
-    "format": "prettier --write . '!(node_modules|.next|contracts)/**/*'",
+    "format": "prettier --write . '!(node_modules|.next)/**/*'",
     "lint": "next lint",
     "serve": "next start",
     "start": "next dev",


### PR DESCRIPTION
Users paste ABIs into `externalContracts.ts` and expect prettier to format on save / `yarn format`. The `contracts/` exclusion in the format script was meant to skip auto-generated `deployedContracts.ts`, but it also caught `externalContracts.ts` — which is user-pasted code that should be formatted.

This change removes `contracts` from the format-ignore pattern so `yarn format` formats `externalContracts.ts` as users expect.

Worth proposing the same change upstream to `scaffold-eth/scaffold-eth-2` since their templates have the same pattern and SE-2 users hit the same friction.