### PR TITLE
docs: deprecate create-eth extensions

### DIFF
--- a/.github/workflows/lint-instances.yml
+++ b/.github/workflows/lint-instances.yml
@@ -13,15 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config:
-          [
-            hardhat,
-            foundry,
-            no_solidity_framework,
-            hardhat_with_extension,
-            foundry_with_extension,
-            no_solidity_framework_with_extension,
-          ]
+        config: [hardhat, foundry, no_solidity_framework]
     steps:
       - uses: actions/checkout@v4
 
@@ -39,14 +31,14 @@ jobs:
         run: yarn
 
       - name: Install Foundry
-        if: matrix.config == 'foundry' || matrix.config == 'foundry_with_extension'
+        if: matrix.config == 'foundry'
         uses: foundry-rs/foundry-toolchain@v1
         with:
           cache: false
           version: v1.4.0
 
       - name: Install foundryup
-        if: matrix.config == 'foundry' || matrix.config == 'foundry_with_extension'
+        if: matrix.config == 'foundry'
         run: |
           curl -L https://foundry.paradigm.xyz -o foundryup-init.sh
           bash foundryup-init.sh
@@ -59,45 +51,31 @@ jobs:
         if: matrix.config == 'hardhat'
         run: yarn cli new_project_hardhat -s hardhat
 
-      - name: Install application (Hardhat with extension configuration)
-        if: matrix.config == 'hardhat_with_extension'
-        run: yarn cli new_project_hardhat_with_extension -s hardhat -e scaffold-eth/create-eth-extensions:example
-
       - name: Install application (Foundry configuration)
         if: matrix.config == 'foundry'
         run: |
           export PATH="$HOME/.config/.foundry/bin:$PATH"
           yarn cli new_project_foundry -s foundry
 
-      - name: Install application (Foundry with extension configuration)
-        if: matrix.config == 'foundry_with_extension'
-        run: |
-          export PATH="$HOME/.config/.foundry/bin:$PATH"
-          yarn cli new_project_foundry_with_extension -s foundry -e scaffold-eth/create-eth-extensions:example
-
       - name: Install application (No solidity framework configuration)
         if: matrix.config == 'no_solidity_framework'
         run: yarn cli new_project_no_solidity_framework -s none
 
-      - name: Install application (No solidity framework with extension configuration)
-        if: matrix.config == 'no_solidity_framework_with_extension'
-        run: yarn cli new_project_no_solidity_framework_with_extension -s none -e scaffold-eth/create-eth-extensions:example
-
       - name: Run chain and deploy
         working-directory: new_project_${{ matrix.config }}
-        if: matrix.config == 'hardhat' || matrix.config == 'foundry' || matrix.config == 'hardhat_with_extension' || matrix.config == 'foundry_with_extension'
+        if: matrix.config == 'hardhat' || matrix.config == 'foundry'
         run: |
           yarn chain &
           npx wait-on tcp:8545
           yarn deploy
 
       - name: Run linting hardhat package
-        if: matrix.config == 'hardhat' || matrix.config == 'hardhat_with_extension'
+        if: matrix.config == 'hardhat'
         working-directory: new_project_${{ matrix.config }}
         run: yarn hardhat:lint --max-warnings=0
 
       - name: Run linting foundry package
-        if: matrix.config == 'foundry' || matrix.config == 'foundry_with_extension'
+        if: matrix.config == 'foundry'
         working-directory: new_project_${{ matrix.config }}
         run: yarn foundry:lint
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,6 @@ Contributions are made via Issues and Pull Requests (PRs). A few general guideli
 - If you're running into an error, please give context. Explain what you're trying to do and how to reproduce the error.
 - Please use the same formatting in the code repository. You can configure your IDE to do it by using the prettier / linting config files included in each package.
 - If applicable, please edit the README.md file to reflect the changes.
-- If you're adding a new template file or modifying arguments of existing templates, please create a corresponding PR to the [Example Extension branch](https://github.com/scaffold-eth/create-eth-extensions/tree/example) of the [create-eth-extensions](https://github.com/scaffold-eth/create-eth-extensions) repository
 
 ### Issues
 

--- a/contributors/DEVELOPER-GUIDE.md
+++ b/contributors/DEVELOPER-GUIDE.md
@@ -29,7 +29,7 @@ You can send any option or flag to the CLI command. For example, a handy command
 
 The source files for the instance projects can be found under `templates/`. You'll see there are two folders there: `base/` and `solidity-frameworks/`. The `base/` folder has the source files that will be present in all instances, whereas `solidity-frameworks/` hold the source files that will be added or not to the instances based on the user choices within the CLI tool.
 
-It's highly recommended that you go through [TEMPLATING.md](TEMPLATING.md) to understand the template API to create extensions. We use a custom template API to allow extensions to modify any file inside the `templates/` folder. While flexible and powerful, it requires developers to understand how it works. It's JS based, so there's no new technology needed to understand and use it.
+It's highly recommended that you go through [TEMPLATING.md](TEMPLATING.md) to understand the template API. We use a custom template API to modify any file inside the `templates/` folder based on the user's choices. While flexible and powerful, it requires developers to understand how it works. It's JS based, so there's no new technology needed to understand and use it.
 
 While you might be tempted to change files straight in the source, we've created a better way to do it with the dev mode. We feel this is worth a separate section in this document.
 
@@ -60,7 +60,7 @@ For example, `generated.txt` would have a sibling `generated.txt.dev` file with 
 While adding or removing the `.template.mjs` file, we make sure we check the below checklist:
 
 - [ ] Add or remove the `.template.mjs` file in the respective directory (check the [`TEMPLATING.md`](./TEMPLATING.md#recommended-way-to-handle-complex-arguments-in-templates))
-- [ ] Add or remove the corresponding `.args.mjs` file from `create-eth-extension` repo [`example`](https://github.com/scaffold-eth/create-eth-extensions/tree/example) branch.
+- [ ] (optional, deprecated) Add or remove the corresponding `.args.mjs` file from your extension repo.
 - [ ] Update the [`TEMPLATE-FILES.md`](./TEMPLATE-FILES.md) file to include or remove the template file.
 - [ ] (optional) If the file was removed then we add the changeset as `minor` update.
 

--- a/contributors/TEMPLATE-FILES.md
+++ b/contributors/TEMPLATE-FILES.md
@@ -1,5 +1,8 @@
 # Template and Args File List
 
+> [!NOTE]
+> **Authoring third-party extensions is deprecated.** The template/args files listed here are still used internally by `create-eth`, but the example args files (linked to the `create-eth-extensions` repo) target extension authoring, which is no longer recommended and will be removed in a future release. Use [skills](https://docs.scaffoldeth.io/build-with-ai) instead.
+
 This document provides a comprehensive list of `.template.mjs` files and their corresponding `.args.mjs` example files used in the `create-eth` project.
 
 Template files are the base files that can be extended by third-party extensions. Args files are used to inject additional content into these template files. Understanding the relationship between these files is crucial for developing extensions and customizing the base instance created by `create-eth`.

--- a/contributors/TEMPLATING.md
+++ b/contributors/TEMPLATING.md
@@ -1,5 +1,8 @@
 # Template files
 
+> [!NOTE]
+> **Authoring third-party extensions is deprecated.** The template/args mechanism documented here is still used internally by `create-eth` to assemble instances, but using it to build extensions is no longer recommended and will be removed in a future release. Use [skills](https://docs.scaffoldeth.io/build-with-ai) instead.
+
 A Template file is a file to which extensions can add content. Removing content is out of scope for this experiment.
 
 ## Template files API

--- a/contributors/THIRD-PARTY-EXTENSION.md
+++ b/contributors/THIRD-PARTY-EXTENSION.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> **Extensions are deprecated.** Third-party extension support still ships with `create-eth` but is no longer recommended and will be removed in a future release. Use [skills](https://docs.scaffoldeth.io/build-with-ai) instead. This guide is retained for existing extension authors.
+
 ## Introduction
 
 Welcome to the guide for developing third-party extensions in the `create-eth` repository. Third-party extensions allow developers to extend the base instance created by `npx create-eth@latest`.


### PR DESCRIPTION
## What

Mark create-eth extensions as deprecated across the docs. No code changes — extensions still ship and work for now; this is docs-only, with removal to follow in a later phase.

## Changes

- `CONTRIBUTING.md` — drop the "create a PR to the example extension branch" contributor guideline.
- `contributors/THIRD-PARTY-EXTENSION.md` — add a deprecation banner (`[!WARNING]`); guide kept for existing extension authors.
- `contributors/TEMPLATING.md` / `TEMPLATE-FILES.md` — add deprecation note (`[!NOTE]`); templating mechanics kept, since create-eth still uses the template/args system internally to assemble instances.
- `contributors/DEVELOPER-GUIDE.md` — reframe the templating intro away from extension-authoring; mark the args-sync checklist item `(optional, deprecated)`.

All deprecation notes point users to skills as the replacement: https://docs.scaffoldeth.io/build-with-ai

Removed extensions from `.github/workflows/lint-instances.yml`:
- Matrix reduced from 6 → 3 configs: [hardhat, foundry, no_solidity_framework] (dropped the three _with_extension variants).
- Removed the 3 "Install application … with extension" steps.
- Simplified the 6 if: conditionals that referenced _with_extension.
  
## Notes

- The user-facing README note (skills instead of extensions) is **not** in this PR — it'll land in scaffold-eth-2 and reach create-eth via backmerge.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
